### PR TITLE
Ability to ban remote ids in endpoint (in lieu of connection close)

### DIFF
--- a/crates/tx5/src/endpoint.rs
+++ b/crates/tx5/src/endpoint.rs
@@ -148,6 +148,13 @@ impl Ep {
         self.state.listener_sig(sig_url)
     }
 
+    /// Close down all connections to, fail all outgoing messages to,
+    /// and drop all incoming messages from, the given remote id,
+    /// for the specified ban time period.
+    pub fn ban(&self, rem_id: Id, span: std::time::Duration) {
+        self.state.ban(rem_id, span);
+    }
+
     /// Send data to a remote on this tx5 endpoint.
     pub fn send<B: bytes::Buf>(
         &self,

--- a/crates/tx5/src/state.rs
+++ b/crates/tx5/src/state.rs
@@ -465,9 +465,7 @@ impl StateData {
 
     fn is_banned(&mut self, rem_id: Id) -> bool {
         let now = std::time::Instant::now();
-        self.ban_map.retain(|_id, expires_at| {
-            *expires_at > now
-        });
+        self.ban_map.retain(|_id, expires_at| *expires_at > now);
         self.ban_map.contains_key(&rem_id)
     }
 
@@ -554,7 +552,11 @@ impl StateData {
             .await
     }
 
-    async fn ban(&mut self, rem_id: Id, span: std::time::Duration) -> Result<()> {
+    async fn ban(
+        &mut self,
+        rem_id: Id,
+        span: std::time::Duration,
+    ) -> Result<()> {
         let expires_at = std::time::Instant::now() + span;
         self.ban_map.insert(rem_id, expires_at);
         self.send_map.remove(&rem_id);


### PR DESCRIPTION
Since tx5 endpoints work as a message queue, opening / retrying connections as needed under the hood, there isn't a direct analog for "Closing" a connection. Yet, holochain still needs this ability if we don't want to speak to a remote node.

This PR introduces the concept of a remote id "ban" where we won't send messages to, accept messages from, or allow connections to a particular remote id for a specified time length. We can consider / configure the length of this ban period in the holochain integration PR, but perhaps ~10 seconds would function as a starting point, since, if they try to re-establish a connection after that time period, we will simply ban them again.