### PR TITLE
Stats and fixes

### DIFF
--- a/crates/tx5-go-pion-sys/build.rs
+++ b/crates/tx5-go-pion-sys/build.rs
@@ -99,15 +99,20 @@ fn go_build() {
     cp("go.mod");
 
     let mut cmd = Command::new("go");
-    cmd.current_dir(out_dir.clone())
-        .env("GOCACHE", cache)
-        .arg("build")
-        .arg("-ldflags") // strip debug symbols
-        .arg("-s -w") // strip debug symbols
-        .arg("-o")
-        .arg(lib_path.clone())
-        .arg("-mod=vendor")
-        .arg("-buildmode=c-shared");
+
+    // grr, clippy, the debug symbols belong in one arg
+    #[allow(clippy::suspicious_command_arg_space)]
+    {
+        cmd.current_dir(out_dir.clone())
+            .env("GOCACHE", cache)
+            .arg("build")
+            .arg("-ldflags") // strip debug symbols
+            .arg("-s -w") // strip debug symbols
+            .arg("-o")
+            .arg(lib_path.clone())
+            .arg("-mod=vendor")
+            .arg("-buildmode=c-shared");
+    }
 
     println!("cargo:warning=NOTE:running go build: {cmd:?}");
 

--- a/crates/tx5-go-pion-turn/build.rs
+++ b/crates/tx5-go-pion-turn/build.rs
@@ -75,14 +75,19 @@ fn go_build(path: &std::path::Path) {
     cp("go.mod");
 
     let mut cmd = Command::new("go");
-    cmd.current_dir(out_dir.clone())
-        .env("GOCACHE", cache)
-        .arg("build")
-        .arg("-ldflags") // strip debug symbols
-        .arg("-s -w") // strip debug symbols
-        .arg("-o")
-        .arg(path)
-        .arg("-mod=vendor");
+
+    // grr, clippy, the debug symbols belong in one arg
+    #[allow(clippy::suspicious_command_arg_space)]
+    {
+        cmd.current_dir(out_dir.clone())
+            .env("GOCACHE", cache)
+            .arg("build")
+            .arg("-ldflags") // strip debug symbols
+            .arg("-s -w") // strip debug symbols
+            .arg("-o")
+            .arg(path)
+            .arg("-mod=vendor");
+    }
 
     println!("cargo:warning=NOTE:running go build: {cmd:?}");
 

--- a/crates/tx5/src/endpoint.rs
+++ b/crates/tx5/src/endpoint.rs
@@ -253,8 +253,6 @@ async fn new_sig_task(
 
     tracing::debug!(%cli_url, "signal connection established");
 
-    tracing::info!(target: "NDBG", cli_url = %cli_url, "signal connection established");
-
     let sig = &sig;
 
     let ice_servers = sig.ice_servers();
@@ -330,7 +328,7 @@ async fn new_sig_task(
         };
     }
 
-    tracing::warn!(target: "NDBG", "signal connection CLOSED");
+    tracing::warn!("signal connection CLOSED");
 }
 
 #[cfg(feature = "backend-go-pion")]
@@ -386,7 +384,7 @@ async fn new_conn_task(
 
     let mut data_chan: Option<tx5_go_pion::DataChannel> = None;
 
-    tracing::info!(target: "NDBG", "PEER CON OPEN");
+    tracing::debug!("PEER CON OPEN");
 
     loop {
         tokio::select! {
@@ -492,13 +490,12 @@ async fn new_conn_task(
                             peer.add_ice_candidate(buf.imp.buf).await
                         }).await;
                     }
-                    Some(Ok(state::ConnStateEvt::SndData(mut buf, mut resp))) => {
+                    Some(Ok(state::ConnStateEvt::SndData(buf, mut resp))) => {
                         let data_chan = &mut data_chan;
                         resp.with(move || async move {
                             match data_chan {
                                 None => Err(Error::id("NoDataChannel")),
                                 Some(chan) => {
-                                    tracing::trace!(target: "NDBG", byte_count = %buf.len().unwrap(), "data chan send");
                                     chan.send(buf.imp.buf).await?;
                                     // TODO - actually report this
                                     Ok(state::BufState::Low)
@@ -520,5 +517,5 @@ async fn new_conn_task(
         };
     }
 
-    tracing::info!(target: "NDBG", "PEER CON CLOSE");
+    tracing::debug!("PEER CON CLOSE");
 }

--- a/crates/tx5/src/state.rs
+++ b/crates/tx5/src/state.rs
@@ -1117,8 +1117,6 @@ impl State {
         cli_url: Tx5Url,
         data: B,
     ) -> impl Future<Output = Result<()>> + 'static + Send {
-        let byte_count = data.remaining();
-
         let buf_list = if !cli_url.is_client() {
             Err(Error::err(
                 "Invalid tx5 signal server url, expect client url",
@@ -1135,16 +1133,6 @@ impl State {
             let msg_uniq = meta.state_uniq.sub();
 
             let buf_list = buf_list?;
-
-            let start = std::time::Instant::now();
-
-            tracing::info!(
-                target: "NDBG",
-                msg_uniq = %msg_uniq,
-                %byte_count,
-                chunks = %buf_list.len(),
-                "send data",
-            );
 
             for (idx, mut buf) in buf_list.into_iter().enumerate() {
                 let len = buf.len()?;
@@ -1196,14 +1184,6 @@ impl State {
                     }
                 }
             }
-
-            tracing::info!(
-                target: "NDBG",
-                msg_uniq = %msg_uniq,
-                %byte_count,
-                elapsed_s = %start.elapsed().as_secs_f64(),
-                "send data COMPLETE",
-            );
 
             Ok(())
         }

--- a/crates/tx5/src/state/conn.rs
+++ b/crates/tx5/src/state/conn.rs
@@ -219,15 +219,21 @@ impl ConnStateEvtSnd {
         let _ = self.0.send(Ok(ConnStateEvt::SndData(data, s)));
     }
 
-    pub async fn stats(&self) -> Result<serde_json::Value> {
-        let (s, r) = tokio::sync::oneshot::channel();
-        self.0
-            .send(Ok(ConnStateEvt::Stats(OneSnd::new(move |stats| {
-                let _ = s.send(stats);
-            }))))
-            .map_err(|_| Error::id("Shutdown"))?;
-        let mut buf = r.await.map_err(|_| Error::id("Shutdown"))??;
-        buf.to_json()
+    pub fn stats(
+        &self,
+        additions: Vec<(String, serde_json::Value)>,
+        rsp: tokio::sync::oneshot::Sender<Result<serde_json::Value>>,
+    ) {
+        let _ = self.0
+            .send(Ok(ConnStateEvt::Stats(OneSnd::new(move |buf: Result<BackBuf>| {
+                let _ = rsp.send((move || {
+                    let mut stats: serde_json::Value = buf?.to_json()?;
+                    for (key, value) in additions {
+                        stats.as_object_mut().unwrap().insert(key, value);
+                    }
+                    Ok(stats)
+                })());
+            }))));
     }
 }
 
@@ -246,6 +252,9 @@ struct ConnStateData {
     rcv_pending:
         HashMap<u64, (BytesList, Vec<tokio::sync::OwnedSemaphorePermit>)>,
     wait_preflight: bool,
+    offer: (u64, u64, u64, u64),
+    answer: (u64, u64, u64, u64),
+    ice: (u64, u64, u64, u64),
 }
 
 impl Drop for ConnStateData {
@@ -299,6 +308,8 @@ impl ConnStateData {
     async fn exec(&mut self, cmd: ConnCmd) -> Result<()> {
         match cmd {
             ConnCmd::Tick1s => self.tick_1s().await,
+            ConnCmd::Stats(rsp) => self.stats(rsp).await,
+            ConnCmd::TrackSig { ty, bytes } => self.track_sig(ty, bytes).await,
             ConnCmd::NotifyConstructed => self.notify_constructed().await,
             ConnCmd::CheckConnectedTimeout => {
                 self.check_connected_timeout().await
@@ -327,6 +338,69 @@ impl ConnStateData {
             && !self.connected()
         {
             self.shutdown(Error::id("InactivityTimeout"));
+        }
+
+        Ok(())
+    }
+
+    async fn stats(&mut self, rsp: tokio::sync::oneshot::Sender<Result<serde_json::Value>>) -> Result<()> {
+        let mut additions = Vec::new();
+        additions.push((
+            "ageSeconds".into(),
+            self.meta.created_at.elapsed().as_secs_f64().into(),
+        ));
+
+        let sig_stats = serde_json::json!({
+            "offersSent": self.offer.0,
+            "offerBytesSent": self.offer.1,
+            "offersReceived": self.offer.2,
+            "offerBytesReceived": self.offer.3,
+            "answersSent": self.answer.0,
+            "answerBytesSent": self.answer.1,
+            "answersReceived": self.answer.2,
+            "answerBytesReceived": self.answer.3,
+            "iceMessagesSent": self.ice.0,
+            "iceBytesSent": self.ice.1,
+            "iceMessagesReceived": self.ice.2,
+            "iceBytesReceived": self.ice.3,
+        });
+        additions.push((
+            "signalingTransport".into(),
+            sig_stats,
+        ));
+
+        self.conn_evt.stats(additions, rsp);
+
+        Ok(())
+    }
+
+    async fn track_sig(&mut self, ty: &'static str, bytes: usize) -> Result<()> {
+        match ty {
+            "offer_out" => {
+                self.offer.0 += 1;
+                self.offer.1 += bytes as u64;
+            }
+            "offer_in" => {
+                self.offer.2 += 1;
+                self.offer.3 += bytes as u64;
+            }
+            "answer_out" => {
+                self.answer.0 += 1;
+                self.answer.1 += bytes as u64;
+            }
+            "answer_in" => {
+                self.answer.2 += 1;
+                self.answer.3 += bytes as u64;
+            }
+            "ice_out" => {
+                self.ice.0 += 1;
+                self.ice.1 += bytes as u64;
+            }
+            "ice_in" => {
+                self.ice.2 += 1;
+                self.ice.3 += bytes as u64;
+            }
+            _ => (),
         }
 
         Ok(())
@@ -611,6 +685,11 @@ impl ConnStateData {
 
 enum ConnCmd {
     Tick1s,
+    Stats(tokio::sync::oneshot::Sender<Result<serde_json::Value>>),
+    TrackSig {
+        ty: &'static str,
+        bytes: usize,
+    },
     NotifyConstructed,
     CheckConnectedTimeout,
     Ice {
@@ -679,11 +758,18 @@ async fn conn_state_task(
         rcv_offer: false,
         rcv_pending: HashMap::new(),
         wait_preflight: true,
+        offer: (0, 0, 0, 0),
+        answer: (0, 0, 0, 0),
+        ice: (0, 0, 0, 0),
     };
 
     let mut permit = None;
 
     let err = match async {
+        if conn_limit.available_permits() < 1 {
+            tracing::warn!(conn_uniq = %data.conn_uniq, "max connections reached, waiting for permit");
+        }
+
         permit = Some(
             conn_limit
                 .acquire_owned()
@@ -726,11 +812,12 @@ async fn conn_state_task(
 
 #[derive(Clone)]
 pub(crate) struct ConnStateMeta {
+    created_at: std::time::Instant,
     cli_url: Tx5Url,
     pub(crate) conn_uniq: Uniq,
     pub(crate) config: DynConfig,
     pub(crate) connected: Arc<atomic::AtomicBool>,
-    conn_snd: ConnStateEvtSnd,
+    _conn_snd: ConnStateEvtSnd,
     pub(crate) rcv_limit: Arc<tokio::sync::Semaphore>,
     pub(crate) metric_bytes_snd: prometheus::IntCounter,
     pub(crate) metric_bytes_rcv: prometheus::IntCounter,
@@ -865,6 +952,10 @@ impl ConnState {
                 std::io::copy(&mut data, &mut buf)?;
                 let buf = buf.into_inner().freeze();
 
+                if self.1.rcv_limit.available_permits() < len {
+                    tracing::warn!(%len, "recv queue full, waiting for permits");
+                }
+
                 let permit = self
                     .1
                     .rcv_limit
@@ -897,7 +988,11 @@ impl ConnState {
 
     /// Get stats.
     pub async fn stats(&self) -> Result<serde_json::Value> {
-        self.1.conn_snd.stats().await
+        let (s, r) = tokio::sync::oneshot::channel();
+        if self.0.send(Ok(ConnCmd::Stats(s))).is_err() {
+            return Err(Error::id("Closed"));
+        }
+        r.await.map_err(|_| Error::id("Closed"))?
     }
 
     // -- //
@@ -963,11 +1058,12 @@ impl ConnState {
             .map_err(Error::err)?;
 
         let meta = ConnStateMeta {
+            created_at: std::time::Instant::now(),
             cli_url,
             conn_uniq: conn_uniq.clone(),
             config: config.clone(),
             connected: Arc::new(atomic::AtomicBool::new(false)),
-            conn_snd: conn_snd.clone(),
+            _conn_snd: conn_snd.clone(),
             rcv_limit,
             metric_bytes_snd,
             metric_bytes_rcv,
@@ -1042,6 +1138,10 @@ impl ConnState {
         self.0.send(Ok(ConnCmd::Tick1s))
     }
 
+    pub(crate) fn track_sig(&self, ty: &'static str, bytes: usize) {
+        let _ = self.0.send(Ok(ConnCmd::TrackSig { ty, bytes }));
+    }
+
     async fn check_connected_timeout(&self) {
         let _ = self.0.send(Ok(ConnCmd::CheckConnectedTimeout));
     }
@@ -1070,7 +1170,9 @@ impl ConnState {
         let _ = self.0.send(Ok(ConnCmd::InAnswer { answer }));
     }
 
-    pub(crate) fn in_ice(&self, ice: BackBuf, cache: bool) {
+    pub(crate) fn in_ice(&self, mut ice: BackBuf, cache: bool) {
+        let bytes = ice.len().unwrap();
+        let _ = self.0.send(Ok(ConnCmd::TrackSig { ty: "ice_in", bytes }));
         let _ = self.0.send(Ok(ConnCmd::InIce { ice, cache }));
     }
 

--- a/crates/tx5/src/state/sig.rs
+++ b/crates/tx5/src/state/sig.rs
@@ -89,7 +89,13 @@ impl SigStateEvtSnd {
         let _ = self.0.send(Err(err));
     }
 
-    pub fn snd_offer(&self, state: StateWeak, sig: SigStateWeak, rem_id: Id, mut offer: BackBuf) {
+    pub fn snd_offer(
+        &self,
+        state: StateWeak,
+        sig: SigStateWeak,
+        rem_id: Id,
+        mut offer: BackBuf,
+    ) {
         if let Some(state) = state.upgrade() {
             state.track_sig(rem_id, "offer_out", offer.len().unwrap());
         }
@@ -103,7 +109,13 @@ impl SigStateEvtSnd {
         let _ = self.0.send(Ok(SigStateEvt::SndOffer(rem_id, offer, s)));
     }
 
-    pub fn snd_answer(&self, state: StateWeak, sig: SigStateWeak, rem_id: Id, mut answer: BackBuf) {
+    pub fn snd_answer(
+        &self,
+        state: StateWeak,
+        sig: SigStateWeak,
+        rem_id: Id,
+        mut answer: BackBuf,
+    ) {
         if let Some(state) = state.upgrade() {
             state.track_sig(rem_id, "answer_out", answer.len().unwrap());
         }
@@ -117,7 +129,13 @@ impl SigStateEvtSnd {
         let _ = self.0.send(Ok(SigStateEvt::SndAnswer(rem_id, answer, s)));
     }
 
-    pub fn snd_ice(&self, state: StateWeak, sig: SigStateWeak, rem_id: Id, mut ice: BackBuf) {
+    pub fn snd_ice(
+        &self,
+        state: StateWeak,
+        sig: SigStateWeak,
+        rem_id: Id,
+        mut ice: BackBuf,
+    ) {
         if let Some(state) = state.upgrade() {
             state.track_sig(rem_id, "ice_out", ice.len().unwrap());
         }
@@ -297,7 +315,7 @@ impl SigStateData {
         if let Some(conn) = self.registered_conn_map.get(&rem_id) {
             if let Some(conn) = conn.upgrade() {
                 conn.in_ice(data, true);
-                return Ok(())
+                return Ok(());
             }
         }
         if let Some(state) = self.state.upgrade() {
@@ -314,17 +332,32 @@ impl SigStateData {
     }
 
     async fn snd_offer(&mut self, rem_id: Id, data: BackBuf) -> Result<()> {
-        self.sig_evt.snd_offer(self.state.clone(), self.this.clone(), rem_id, data);
+        self.sig_evt.snd_offer(
+            self.state.clone(),
+            self.this.clone(),
+            rem_id,
+            data,
+        );
         Ok(())
     }
 
     async fn snd_answer(&mut self, rem_id: Id, data: BackBuf) -> Result<()> {
-        self.sig_evt.snd_answer(self.state.clone(), self.this.clone(), rem_id, data);
+        self.sig_evt.snd_answer(
+            self.state.clone(),
+            self.this.clone(),
+            rem_id,
+            data,
+        );
         Ok(())
     }
 
     async fn snd_ice(&mut self, rem_id: Id, data: BackBuf) -> Result<()> {
-        self.sig_evt.snd_ice(self.state.clone(), self.this.clone(), rem_id, data);
+        self.sig_evt.snd_ice(
+            self.state.clone(),
+            self.this.clone(),
+            rem_id,
+            data,
+        );
         Ok(())
     }
 

--- a/crates/tx5/src/test.rs
+++ b/crates/tx5/src/test.rs
@@ -63,6 +63,9 @@ async fn endpoint_sanity() {
         oth => panic!("unexpected {:?}", oth),
     }
 
+    ep1.ban([42; 32].into(), std::time::Duration::from_secs(42));
+    ep2.ban([43; 32].into(), std::time::Duration::from_secs(43));
+
     println!(
         "{}",
         serde_json::to_string_pretty(&ep1.get_stats().await.unwrap()).unwrap()


### PR DESCRIPTION
- Adds some additional information to the stats output
- Fixes an ice message race by ensuring messages are cached if a conn has yet to be created
- Stop shutting down the whole endpoint on processing errors like banned connections
- Fixes a race condition associated with the "Connected" event