### PR TITLE
use webpki-roots on systems where native-certs doesn't work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3371,7 @@ dependencies = [
  "tx5-core",
  "tx5-signal-srv",
  "url",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -3468,7 +3479,7 @@ dependencies = [
  "rustls 0.20.8",
  "url",
  "webpki 0.22.0",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -3675,6 +3686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,6 @@ tx5-signal = { version = "0.0.1-alpha.9", path = "crates/tx5-signal" }
 tx5 = { version = "0.0.1-alpha.16", path = "crates/tx5" }
 url = { version = "2.3.1", features = [ "serde" ] }
 warp = { version = "0.3.4", features = [ "websocket" ] }
+webpki-roots = { version = "0.23.0" }
 webrtc = { version = "0.7.1" }
 zip = { version = "0.6.4", default-features = false, features = [ "deflate" ] }

--- a/crates/tx5-signal/Cargo.toml
+++ b/crates/tx5-signal/Cargo.toml
@@ -32,6 +32,9 @@ tracing = { workspace = true }
 tx5-core = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))'.dependencies]
+webpki-roots = { workspace = true }
+
 [dev-dependencies]
 rand = { workspace = true }
 rand-utf8 = { workspace = true }

--- a/crates/tx5-signal/src/cli.rs
+++ b/crates/tx5-signal/src/cli.rs
@@ -132,6 +132,29 @@ impl CliBuilder {
 
 fn priv_system_tls() -> Arc<rustls::ClientConfig> {
     let mut roots = rustls::RootCertStore::empty();
+
+    #[cfg(not(any(
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "macos"
+    )))]
+    {
+        roots.add_server_trust_anchors(
+            webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|a| {
+                rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    a.subject.to_vec(),
+                    a.spki.to_vec(),
+                    a.name_constraints.map(|c| c.to_vec()),
+                )
+            }),
+        );
+    }
+
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "macos"
+    ))]
     for cert in rustls_native_certs::load_native_certs()
         .expect("failed to load system tls certs")
     {


### PR DESCRIPTION
RESOLVES #34