### PR TITLE
android ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,14 +11,29 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
+        #android-arch: ["arm64-v8a", "x86_64"]
+        android-arch: ["x86_64"]
         android-api-level: [29]
         android-ndk-version: ["26.0.10792818"]
-        android-arch: ["arm64-v8a", "x86_64"]
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: AVD cache
+      - name: Go Toolchain
+        uses: actions/setup-go@v3
+        with:
+          go-version: '=1.18.0'
+
+      - name: Rust Toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup target add aarch64-linux-android
+          rustup target add x86_64-linux-android
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Avd Cache
         uses: actions/cache@v3
         id: avd-cache
         with:
@@ -27,7 +42,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.android-api-level }}
 
-      - name: create AVD and generate snapshot for caching
+      - name: Avd Snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         env:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
@@ -42,14 +57,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: echo "Generated AVD snapshot for caching." && /usr/bin/env
+          script: echo "Generated AVD snapshot for caching."
 
-      - name: run tests
+      - name: Build Tests
         env:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
-          ANDROID_SDK_ROOT: ~/Android/Sdk
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}
@@ -59,4 +73,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: which adb; ./android-build-tests.bash
+          script: ./android-build-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,7 +59,7 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Build Tests
+      - name: Build and Run Tests
         env:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
@@ -73,4 +73,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./android-build-tests.bash
+          script: ./android-build-tests.bash && ./android-run-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         android-api-level: [34]
         android-ndk-version: ["26.0.10792818"]
-        android-arch: ["aarch64", "x86_64"]
+        android-arch: ["arm64-v8a", "x86_64"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,8 +13,7 @@ jobs:
       matrix:
         android-api-level: [34]
         android-ndk-version: ["26.0.10792818"]
-        android-arch: ["x86_64"]
-        #android-arch: ["arm64-v8a", "x86_64"]
+        android-arch: ["arm64-v8a", "x86_64"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -28,18 +27,36 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.android-api-level }}
 
-      - name: run tests
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         env:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
-          #ANDROID_SDK_ROOT: ~/Android/Sdk
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}
           ndk: ${{ matrix.android-ndk-version }}
           arch: ${{ matrix.android-arch }}
+          target: google_apis
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching." && /usr/bin/env
+
+      - name: run tests
+        env:
+          ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
+          ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
+          ANDROID_ARCH: ${{ matrix.android-arch }}
+          ANDROID_SDK_ROOT: ~/Android/Sdk
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.android-api-level }}
+          ndk: ${{ matrix.android-ndk-version }}
+          arch: ${{ matrix.android-arch }}
+          target: google_apis
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: /usr/bin/env; which adb; ./android-build-tests.bash
+          script: which adb; ./android-build-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,12 +27,12 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.android-api-level }}
 
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+      - name: run tests
         env:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
+          #ANDROID_SDK_ROOT: ~/Android/Sdk
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}
@@ -40,21 +40,5 @@ jobs:
           arch: ${{ matrix.android-arch }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching." && /usr/bin/env
-
-      - name: run tests
-        env:
-          ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
-          ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
-          ANDROID_ARCH: ${{ matrix.android-arch }}
-          ANDROID_SDK_ROOT: ~/Android/Sdk
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.android-api-level }}
-          ndk: ${{ matrix.android-ndk-version }}
-          arch: ${{ matrix.android-arch }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: which adb; ./android-build-tests.bash
+          script: /usr/bin/env; which adb; ./android-build-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Rust Toolchain
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
-          rustup target add aarch64-linux-android
+          #rustup target add aarch64-linux-android
           rustup target add x86_64-linux-android
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+      #- name: Rust Cache
+      #  uses: Swatinem/rust-cache@v2
 
       - name: Avd Cache
         uses: actions/cache@v3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,52 @@
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        android-api-level: [34]
+        android-ndk-version: ["26.0.10792818"]
+        android-arch: ["aarch64", "x86_64"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.android-api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        env:
+          ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
+          ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
+          ANDROID_ARCH: ${{ matrix.android-arch }}
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.android-api-level }}
+          ndk: ${{ matrix.android-ndk-version }}
+          arch: ${{ matrix.android-arch }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching." && /usr/bin/env
+
+      - name: run tests
+        env:
+          ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
+          ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
+          ANDROID_ARCH: ${{ matrix.android-arch }}
+          ANDROID_SDK_ROOT: ~/Android/Sdk
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.android-api-level }}
+          ndk: ${{ matrix.android-ndk-version }}
+          arch: ${{ matrix.android-arch }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: which adb; ./android-build-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,8 +30,8 @@ jobs:
           #rustup target add aarch64-linux-android
           rustup target add x86_64-linux-android
 
-      #- name: Rust Cache
-      #  uses: Swatinem/rust-cache@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Avd Cache
         uses: actions/cache@v3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,3 +1,11 @@
+name: Android Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         android-api-level: [34]
         android-ndk-version: ["26.0.10792818"]
-        android-arch: ["arm64-v8a", "x86_64"]
+        android-arch: ["x86_64"]
+        #android-arch: ["arm64-v8a", "x86_64"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        android-api-level: [34]
+        android-api-level: [29]
         android-ndk-version: ["26.0.10792818"]
         android-arch: ["arm64-v8a", "x86_64"]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/output-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.28.0+1.1.1w"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce95ee1f6f999dfb95b8afd43ebe442758ea2104d1ccb99a94c30db22ae701f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2229,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3788,6 +3798,7 @@ dependencies = [
  "influxive-child-svc",
  "influxive-otel-atomic-obs",
  "once_cell",
+ "openssl-sys",
  "parking_lot",
  "rand",
  "rand-utf8",
@@ -3832,6 +3843,7 @@ dependencies = [
  "clap",
  "futures",
  "influxive",
+ "openssl-sys",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
   "crates/tx5-go-pion-turn",
 ]
 
+[profile.release]
+strip = true
+
 [workspace.dependencies]
 base64 = "0.13.0"
 bytes = "1.4.0"
@@ -28,6 +31,7 @@ lair_keystore_api = "0.3.0"
 libc = "0.2.141"
 libloading = "0.8.0"
 once_cell = "1.17.1"
+openssl-sys = { version = "0.9.90", features = [ "vendored" ] }
 opentelemetry_api = { version = "=0.20.0-beta.1", features = [ "metrics" ], package = "ts_opentelemetry_api" }
 ouroboros = "0.15.6"
 parking_lot = "0.12.1"

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ tool_clippy: tool_rust
 tool_readme: tool_rust
 	@if ! (cargo rdme --version); \
 	then \
-		cargo install cargo-rdme --version 1.4.0; \
+		cargo install cargo-rdme --version 1.4.0 --locked; \
 	else \
 		echo "# Makefile # readme ok"; \
 	fi;

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -32,12 +32,10 @@ EOF
 
 export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
 export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
-export CFLAGS="-I${_ndk_root}/sysroot/usr/include"
-export CFLAGS="-I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
+export CFLAGS="-I${_ndk_root}/sysroot/usr/include -I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
 export AR="${_ndk_root}/bin/llvm-ar"
 export RANLIB="${_ndk_root}/bin/llvm-ranlib"
-export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include"
-export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
+export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include -I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
 
 cargo test --no-run --release --target ${ANDROID_ARCH}-linux-android --config target.${ANDROID_ARCH}-linux-android.linker="\"${_ndk_root}/bin/${ANDROID_ARCH}-linux-android34-clang\"" --config target.${ANDROID_ARCH}-linux-android.ar="\"${_ndk_root}/bin/llvm-ar\"" 2>&1 | tee output-cargo-test
 cat output-cargo-test | grep Executable | sed -E 's/[^(]*\(([^)]*)\)/\1/' > output-test-executables

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -1,31 +1,35 @@
 #!/bin/bash
 
-if [[ "x${ANDROID_API_LEVEL}" == "x" ]]; then
+set -eEuxo pipefail
+
+if [[ "${ANDROID_API_LEVEL:-x}" == "x" ]]; then
   echo "ANDROID_API_LEVEL required"
   exit 127
 fi
 
-if [[ "x${ANDROID_NDK_VERSION}" == "x" ]]; then
+if [[ "${ANDROID_NDK_VERSION:-x}" == "x" ]]; then
   echo "ANDROID_NDK_VERSION required"
   exit 127
 fi
 
-if [[ "x${ANDROID_ARCH}" == "x" ]]; then
+if [[ "${ANDROID_ARCH:-x}" == "x" ]]; then
   echo "ANDROID_ARCH required"
   exit 127
+else
+  if [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]; then
+    export ANDROID_ARCH="aarch64"
+  fi
 fi
 
-if [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]; then
-  export ANDROID_ARCH="aarch64"
-fi
 
-if [[ "x${ANDROID_SDK_ROOT}" == "x" ]]; then
+if [[ "${ANDROID_SDK_ROOT:-x}" == "x" ]]; then
   echo "ANDROID_SDK_ROOT required"
   exit 127
 fi
 
 _ndk_root=(${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/*)
 
+# This workaround may be needed if upgrading android api level
 #cat << EOF > ${_ndk_root}/lib/clang/17/lib/linux/${ANDROID_ARCH}/libgcc.a
 #INPUT(-lunwind)
 #EOF

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [[ "x${ANDROID_API_LEVEL}" == "x" ]]; then
+  echo "ANDROID_API_LEVEL required"
+  exit 127
+fi
+
+if [[ "x${ANDROID_NDK_VERSION}" == "x" ]]; then
+  echo "ANDROID_NDK_VERSION required"
+  exit 127
+fi
+
+if [[ "x${ANDROID_ARCH}" == "x" ]]; then
+  echo "ANDROID_ARCH required"
+  exit 127
+fi
+
+if [[ "x${ANDROID_SDK_ROOT}" == "x" ]]; then
+  echo "ANDROID_SDK_ROOT required"
+  exit 127
+fi
+
+_ndk_root=(${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/*)
+
+cat << EOF > ${_ndk_root}/lib/clang/17/lib/linux/${ANDROID_ARCH}/libgcc.a
+INPUT(-lunwind)
+EOF
+
+export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
+export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
+export AR="${_ndk_root}/bin/llvm-ar"
+export RANLIB="${_ndk_root}/bin/llvm-ranlib"
+export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include"
+
+cargo test --no-run --release --target ${ANDROID_ARCH}-linux-android --config target.${ANDROID_ARCH}-linux-android.linker="\"${_ndk_root}/bin/${ANDROID_ARCH}-linux-android34-clang\"" --config target.${ANDROID_ARCH}-linux-android.ar="\"${_ndk_root}/bin/llvm-ar\"" 2>&1 | tee output-cargo-test
+cat output-cargo-test | grep Executable | sed -E 's/[^(]*\(([^)]*)\)/\1/' > output-test-executables

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -33,9 +33,11 @@ EOF
 export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
 export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
 export CFLAGS="-I${_ndk_root}/sysroot/usr/include"
+export CFLAGS="-I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
 export AR="${_ndk_root}/bin/llvm-ar"
 export RANLIB="${_ndk_root}/bin/llvm-ranlib"
 export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include"
+export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
 
 cargo test --no-run --release --target ${ANDROID_ARCH}-linux-android --config target.${ANDROID_ARCH}-linux-android.linker="\"${_ndk_root}/bin/${ANDROID_ARCH}-linux-android34-clang\"" --config target.${ANDROID_ARCH}-linux-android.ar="\"${_ndk_root}/bin/llvm-ar\"" 2>&1 | tee output-cargo-test
 cat output-cargo-test | grep Executable | sed -E 's/[^(]*\(([^)]*)\)/\1/' > output-test-executables

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -31,10 +31,10 @@ _ndk_root=(${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebui
 #EOF
 
 export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
-export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
-export CFLAGS="-I${_ndk_root}/sysroot/usr/include -I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
-export AR="${_ndk_root}/bin/llvm-ar"
-export RANLIB="${_ndk_root}/bin/llvm-ranlib"
+export TARGET_CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
+export TARGET_CFLAGS="-I${_ndk_root}/sysroot/usr/include -I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
+export TARGET_AR="${_ndk_root}/bin/llvm-ar"
+export TARGET_RANLIB="${_ndk_root}/bin/llvm-ranlib"
 export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include -I${_ndk_root}/sysroot/usr/include/${ANDROID_ARCH}-linux-android"
 
 cargo test --no-run --release --target ${ANDROID_ARCH}-linux-android --config target.${ANDROID_ARCH}-linux-android.linker="\"${_ndk_root}/bin/${ANDROID_ARCH}-linux-android34-clang\"" --config target.${ANDROID_ARCH}-linux-android.ar="\"${_ndk_root}/bin/llvm-ar\"" 2>&1 | tee output-cargo-test

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -26,9 +26,9 @@ fi
 
 _ndk_root=(${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/*)
 
-cat << EOF > ${_ndk_root}/lib/clang/17/lib/linux/${ANDROID_ARCH}/libgcc.a
-INPUT(-lunwind)
-EOF
+#cat << EOF > ${_ndk_root}/lib/clang/17/lib/linux/${ANDROID_ARCH}/libgcc.a
+#INPUT(-lunwind)
+#EOF
 
 export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
 export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -15,6 +15,10 @@ if [[ "x${ANDROID_ARCH}" == "x" ]]; then
   exit 127
 fi
 
+if [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]; then
+  export ANDROID_ARCH="aarch64"
+fi
+
 if [[ "x${ANDROID_SDK_ROOT}" == "x" ]]; then
   echo "ANDROID_SDK_ROOT required"
   exit 127
@@ -34,3 +38,5 @@ export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include"
 
 cargo test --no-run --release --target ${ANDROID_ARCH}-linux-android --config target.${ANDROID_ARCH}-linux-android.linker="\"${_ndk_root}/bin/${ANDROID_ARCH}-linux-android34-clang\"" --config target.${ANDROID_ARCH}-linux-android.ar="\"${_ndk_root}/bin/llvm-ar\"" 2>&1 | tee output-cargo-test
 cat output-cargo-test | grep Executable | sed -E 's/[^(]*\(([^)]*)\)/\1/' > output-test-executables
+echo "BUILD TESTS:"
+cat output-test-executables

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -32,6 +32,7 @@ EOF
 
 export PKG_CONFIG_SYSROOT_DIR="${_ndk_root}/sysroot"
 export CC="${_ndk_root}/bin/${ANDROID_ARCH}-linux-android${ANDROID_API_LEVEL}-clang"
+export CFLAGS="-I${_ndk_root}/sysroot/usr/include"
 export AR="${_ndk_root}/bin/llvm-ar"
 export RANLIB="${_ndk_root}/bin/llvm-ranlib"
 export CGO_CFLAGS="-I${_ndk_root}/sysroot/usr/include"

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for i in $(cat output-test-executables); do
+  adb push $i /data/local/tmp/$(basename $i)
+  adb shell /data/local/tmp/$(basename $i)
+done

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eEuxo pipefail
+
 for i in $(cat output-test-executables); do
   adb push $i /data/local/tmp/$(basename $i)
   adb shell /data/local/tmp/$(basename $i)

--- a/crates/tx5-demo/Cargo.toml
+++ b/crates/tx5-demo/Cargo.toml
@@ -16,6 +16,7 @@ bytes = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 influxive = { workspace = true }
+openssl-sys = { workspace = true }
 opentelemetry_api = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/crates/tx5-go-pion-sys/build.rs
+++ b/crates/tx5-go-pion-sys/build.rs
@@ -63,17 +63,19 @@ fn go_build() {
 
     let mut lib_path = out_dir.clone();
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-    lib_path.push("go-pion-webrtc.dylib");
-    #[cfg(target_os = "windows")]
-    lib_path.push("go-pion-webrtc.dll");
-    #[cfg(not(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "windows"
-    )))]
-    lib_path.push("go-pion-webrtc.so");
+    let tgt_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    match tgt_os.as_str() {
+        "macos" | "ios" | "tvos" => {
+            lib_path.push("go-pion-webrtc.dylib");
+        }
+        "windows" => {
+            lib_path.push("go-pion-webrtc.dll");
+        }
+        _ => {
+            lib_path.push("go-pion-webrtc.so");
+        }
+    }
 
     let mut cache = out_dir.clone();
     cache.push("go-build");
@@ -101,14 +103,61 @@ fn go_build() {
     let mut cmd = Command::new("go");
 
     // add some cross-compilation translators:
-    #[cfg(target_arch = "arm")]
-    cmd.env("GOARCH", "arm");
-    #[cfg(target_arch = "aarch64")]
-    cmd.env("GOARCH", "arm64");
-    #[cfg(target_arch = "x86_64")]
-    cmd.env("GOARCH", "amd64");
-    #[cfg(target_arch = "x86")]
-    cmd.env("GOARCH", "386");
+    match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+        "arm" => {
+            cmd.env("GOARCH", "arm");
+        }
+        "aarch64" => {
+            cmd.env("GOARCH", "arm64");
+        }
+        "x86_64" => {
+            cmd.env("GOARCH", "amd64");
+        }
+        "x86" => {
+            cmd.env("GOARCH", "386");
+        }
+        _ => (),
+    }
+
+    // and for the os
+    match tgt_os.as_str() {
+        "windows" => {
+            cmd.env("GOOS", "windows");
+        }
+        "macos" => {
+            cmd.env("GOOS", "darwin");
+        }
+        "ios" => {
+            cmd.env("GOOS", "ios");
+        }
+        "linux" => {
+            cmd.env("GOOS", "linux");
+        }
+        "android" => {
+            cmd.env("GOOS", "android");
+        }
+        "dragonfly" => {
+            cmd.env("GOOS", "dragonfly");
+        }
+        "freebsd" => {
+            cmd.env("GOOS", "freebsd");
+        }
+        "openbsd" => {
+            cmd.env("GOOS", "openbsd");
+        }
+        "netbsd" => {
+            cmd.env("GOOS", "netbsd");
+        }
+        _ => (),
+    }
+
+    if tgt_os == "android" {
+        let linker = std::env::var("RUSTC_LINKER").unwrap();
+        println!("cargo:warning=LINKER: {linker:?}");
+        cmd.env("CC_FOR_TARGET", &linker);
+        cmd.env("CC", &linker);
+        cmd.env("CGO_ENABLED", "1");
+    }
 
     // grr, clippy, the debug symbols belong in one arg
     #[allow(clippy::suspicious_command_arg_space)]

--- a/crates/tx5-go-pion-turn/build.rs
+++ b/crates/tx5-go-pion-turn/build.rs
@@ -77,14 +77,62 @@ fn go_build(path: &std::path::Path) {
     let mut cmd = Command::new("go");
 
     // add some cross-compilation translators:
-    #[cfg(target_arch = "arm")]
-    cmd.env("GOARCH", "arm");
-    #[cfg(target_arch = "aarch64")]
-    cmd.env("GOARCH", "arm64");
-    #[cfg(target_arch = "x86_64")]
-    cmd.env("GOARCH", "amd64");
-    #[cfg(target_arch = "x86")]
-    cmd.env("GOARCH", "386");
+    match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+        "arm" => {
+            cmd.env("GOARCH", "arm");
+        }
+        "aarch64" => {
+            cmd.env("GOARCH", "arm64");
+        }
+        "x86_64" => {
+            cmd.env("GOARCH", "amd64");
+        }
+        "x86" => {
+            cmd.env("GOARCH", "386");
+        }
+        _ => (),
+    }
+
+    // and for the os
+    let tgt_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    match tgt_os.as_str() {
+        "windows" => {
+            cmd.env("GOOS", "windows");
+        }
+        "macos" => {
+            cmd.env("GOOS", "darwin");
+        }
+        "ios" => {
+            cmd.env("GOOS", "ios");
+        }
+        "linux" => {
+            cmd.env("GOOS", "linux");
+        }
+        "android" => {
+            cmd.env("GOOS", "android");
+        }
+        "dragonfly" => {
+            cmd.env("GOOS", "dragonfly");
+        }
+        "freebsd" => {
+            cmd.env("GOOS", "freebsd");
+        }
+        "openbsd" => {
+            cmd.env("GOOS", "openbsd");
+        }
+        "netbsd" => {
+            cmd.env("GOOS", "netbsd");
+        }
+        _ => (),
+    }
+
+    if tgt_os == "android" {
+        let linker = std::env::var("RUSTC_LINKER").unwrap();
+        println!("cargo:warning=LINKER: {linker:?}");
+        cmd.env("CC_FOR_TARGET", &linker);
+        cmd.env("CC", &linker);
+        cmd.env("CGO_ENABLED", "1");
+    }
 
     // grr, clippy, the debug symbols belong in one arg
     #[allow(clippy::suspicious_command_arg_space)]

--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -42,6 +42,7 @@ webrtc = { workspace = true, optional = true }
 criterion = { workspace = true }
 influxive-child-svc = { workspace = true }
 influxive = { workspace = true }
+openssl-sys = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [ "macros", "rt", "rt-multi-thread", "sync" ] }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
- Only running x86_64 for now because it's faster and shows problems. Once those problems are fixed, we can up the timeout for starting an aarch64 emulator and running the tests on it.

Now we can see the actual errors that need fixing, namely:

- `thread 'state::test::extended_outgoing' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "[Custom { kind: Other, error: \"failed to run \\\"influxd\\\"\" }, Os { code: 2, kind: NotFound, message: \"No such file or directory\" }, Custom { kind: Other, error: \"no download configured for this target os/arch\" }]" }', crates/tx5/src/state/test.rs:53:14`
- `thread 'tokio-runtime-worker' panicked at 'assertion failed: flags.is_empty()', /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustix-0.37.20/src/backend/libc/fs/syscalls.rs:418:5`