### PR TITLE
Use app_dirs2 UserCache directory for storing go lib by default, overridable via env variable

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,8 +74,6 @@ jobs:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
-          CARGO_CFG_TARGET_OS: android
-          TX5_CACHE_DIRECTORY: /data/local/tmp/
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,6 +81,6 @@ jobs:
           arch: ${{ matrix.android-arch }}
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -writable-system
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./android-build-tests.bash && ./android-run-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,7 @@ jobs:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
+          CARGO_CFG_TARGET_OS: android
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,6 +81,6 @@ jobs:
           arch: ${{ matrix.android-arch }}
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -writable-system
           disable-animations: true
           script: ./android-build-tests.bash && ./android-run-tests.bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -75,6 +75,7 @@ jobs:
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
           CARGO_CFG_TARGET_OS: android
+          TX5_CACHE_DIRECTORY: /data/local/tmp/
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -2,8 +2,6 @@
 
 set -eEuxo pipefail
 
-export TX5_CACHE_DIRECTORY=/data/local/tmp/
-
 trap 'cleanup' ERR EXIT
 cleanup() {
   for i in $(cat output-test-executables); do
@@ -14,6 +12,6 @@ cleanup() {
 for i in $(cat output-test-executables); do
   adb push $i /data/local/tmp/$(basename $i)
   adb shell chmod 500 /data/local/tmp/$(basename $i)
-  adb shell RUST_LOG=error RUST_BACKTRACE=1 /data/local/tmp/$(basename $i) --test-threads 1 --nocapture
+  adb shell TX5_CACHE_DIRECTORY=/data/local/tmp/ RUST_LOG=error RUST_BACKTRACE=1 /data/local/tmp/$(basename $i) --test-threads 1 --nocapture
   adb shell rm -f /data/local/tmp/$(basename $i)
 done

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -2,6 +2,8 @@
 
 set -eEuxo pipefail
 
+export TX5_CACHE_DIRECTORY=/data/local/tmp/
+
 trap 'cleanup' ERR EXIT
 cleanup() {
   for i in $(cat output-test-executables); do

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -26,11 +26,12 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
     match std::env::var("TX5_CACHE_DIRECTORY") {
         Ok(cache_dir) => {
             let path = PathBuf::from(cache_dir);
-
+            println!("get_cache_dir TX5_CACHE_DIRECTORY={:?}", path);
+            tracing::debug!("get_cache_dir TX5_CACHE_DIRECTORY={:?}", path);
             if path.is_dir() {
-                Ok(path.to_path_buf())
+                Ok(path)
             } else {
-                Err(std::io::Error::other("env variable TX5_CACHE_DIRECTORY must be a valid path to a directory"))
+                Err(std::io::Error::other("env variable TX5_CACHE_DIRECTORY is not a valid path to an existing directory"))
             }
         }
         Err(_) => app_dirs2::app_root(

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -31,7 +31,7 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
             if path.is_dir() {
                 Ok(path)
             } else {
-                Err(std::io::Error::other("env variable TX5_CACHE_DIRECTORY is not a valid path to an existing directory"))
+                Err(std::io::Error::other("env variable TX5_CACHE_DIRECTORY is set, but it is not a valid path to an existing directory"))
             }
         }
         Err(_) => app_dirs2::app_root(
@@ -253,8 +253,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn file_check_env_variable_override() {
         let tmpdir = tempfile::tempdir().unwrap();
-        let tmpdir_path = tmpdir.path();
-        std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.as_os_str());
+        let tmpdir_path = tmpdir.into_path();
+        std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.clone().as_os_str());
 
         use rand::Rng;
         let mut data = vec![0; 1024 * 1024 * 10]; // 10 MiB
@@ -280,7 +280,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.path.starts_with(tmpdir_path));
+        assert!(res.path.starts_with(tmpdir_path.clone()));
 
         // cleanup
         let path = res.path().to_owned();

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -18,6 +18,7 @@ impl FileCheck {
     }
 }
 
+#[cfg(not(all(test, target_os = "android")))]
 fn get_user_cache_dir() -> Result<std::path::PathBuf> {
     app_dirs2::app_root(
         app_dirs2::AppDataType::UserCache,
@@ -27,6 +28,11 @@ fn get_user_cache_dir() -> Result<std::path::PathBuf> {
         },
     )
     .map_err(std::io::Error::other)
+}
+
+#[cfg(all(test, target_os = "android"))]
+fn get_user_cache_dir() -> Result<std::path::PathBuf> {
+    Ok(PathBuf::from("/data/local/tmp/"))
 }
 
 /// Write a temp file if needed, verify the file, and return a handle to that file.

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -20,6 +20,9 @@ impl FileCheck {
 
 #[cfg(not(all(test, target_os = "android")))]
 fn get_user_cache_dir() -> Result<std::path::PathBuf> {
+    println!("get_user_cache_dir not android test");
+    tracing::debug!("get_user_cache_dir not android test");
+
     app_dirs2::app_root(
         app_dirs2::AppDataType::UserCache,
         &app_dirs2::AppInfo {
@@ -32,6 +35,9 @@ fn get_user_cache_dir() -> Result<std::path::PathBuf> {
 
 #[cfg(all(test, target_os = "android"))]
 fn get_user_cache_dir() -> Result<std::path::PathBuf> {
+    println!("get_user_cache_dir android test");
+    tracing::debug!("get_user_cache_dir android test");
+
     Ok(PathBuf::from("/data/local/tmp/"))
 }
 

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -26,7 +26,7 @@ fn get_user_cache_dir() -> Result<std::path::PathBuf> {
             author: "host.holo.tx5",
         },
     )
-    .map_err(|err| std::io::Error::other(err))
+    .map_err(std::io::Error::other)
 }
 
 /// Write a temp file if needed, verify the file, and return a handle to that file.

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -250,8 +250,8 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn file_check_env_variable_override() {
+    #[test]
+    fn file_check_env_variable_override() {
         let tmpdir = tempfile::tempdir().unwrap();
         let tmpdir_path = tmpdir.into_path();
         std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.clone().as_os_str());

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -44,10 +44,6 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
 }
 
 /// Write a temp file if needed, verify the file, and return a handle to that file.
-///
-/// This will panic on Android targets if run on a physical device (not an emulator) that is *not* rooted.
-/// To avoid panic on a physical, non-rooted Android device
-/// set the env variable TX5_CACHE_DIRECTORY to app_dirs2 UserCache directory with the correct identifier for your android app
 pub fn file_check(
     file_data: &[u8],
     file_hash: &str,

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -19,7 +19,7 @@ impl FileCheck {
 }
 
 /// Get a path to a cache directory where the dependency Pion library can be written
-/// 
+///
 /// Defaults to the UserCache directory returned by app_dirs2, specific to the target platform.
 /// Overridable via the env variable TX5_CACHE_DIRECTORY
 fn get_cache_dir() -> Result<std::path::PathBuf> {
@@ -32,7 +32,7 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
             } else {
                 Err(std::io::Error::other("env variable TX5_CACHE_DIRECTORY must be a valid path to a directory"))
             }
-        },
+        }
         Err(_) => app_dirs2::app_root(
             app_dirs2::AppDataType::UserCache,
             &app_dirs2::AppInfo {
@@ -40,7 +40,7 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
                 author: "host.holo.tx5",
             },
         )
-        .map_err(std::io::Error::other)
+        .map_err(std::io::Error::other),
     }
 }
 
@@ -270,14 +270,15 @@ mod tests {
 
         let data = data.clone();
         let hash = hash.clone();
-    
+
         let res = file_check(
             data.as_slice(),
             &hash,
             "tx5-core-file-check-test",
             ".data",
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         assert!(res.path.starts_with(tmpdir_path));
 
         // cleanup

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -255,6 +255,7 @@ mod tests {
         let _ = tempfile::tempdir().unwrap();
         let tmpdir = tempfile::tempdir().unwrap();
         let tmpdir_path = tmpdir.path();
+        let original_tx5_cache_directory = std::env::var("TX5_CACHE_DIRECTORY");
         std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.as_os_str());
 
         use rand::Rng;
@@ -285,7 +286,10 @@ mod tests {
 
         // cleanup
         let path = res.path().to_owned();
-        std::env::remove_var("TX5_CACHE_DIRECTORY");
+        match original_tx5_cache_directory {
+            Ok(dir) => std::env::set_var("TX5_CACHE_DIRECTORY", dir),
+            Err(_) => std::env::remove_var("TX5_CACHE_DIRECTORY"),
+        };
         drop(res);
         let _ = std::fs::remove_file(path);
     }

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -43,7 +43,12 @@ pub fn file_check(
     file_name_ext: &str,
 ) -> Result<FileCheck> {
     let file_name = format!("{file_name_prefix}-{file_hash}{file_name_ext}");
+    println!("File check file_name={:?}", file_name);
+    tracing::debug!("File check file_name={:?}", file_name);
+
     let tmp_dir = get_user_cache_dir()?;
+    println!("File check tmp_dir={:?}", tmp_dir);
+    tracing::debug!("File check tmp_dir={:?}", tmp_dir);
 
     let mut pref_path = tmp_dir.clone();
     pref_path.push(&file_name);

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -26,7 +26,7 @@ fn get_user_cache_dir() -> Result<std::path::PathBuf> {
             author: "host.holo.tx5",
         },
     )
-    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
+    .map_err(|err| std::io::Error::other(err))
 }
 
 /// Write a temp file if needed, verify the file, and return a handle to that file.

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -48,6 +48,8 @@ pub fn file_check(
     let mut pref_path = tmp_dir.clone();
     pref_path.push(&file_name);
 
+    println!("File check {:?}", pref_path);
+
     if let Ok(file) = validate(&pref_path, file_hash) {
         return Ok(FileCheck {
             path: pref_path.clone(),

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -252,9 +252,10 @@ mod tests {
 
     #[test]
     fn file_check_env_variable_override() {
+        let _ = tempfile::tempdir().unwrap();
         let tmpdir = tempfile::tempdir().unwrap();
-        let tmpdir_path = tmpdir.into_path();
-        std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.clone().as_os_str());
+        let tmpdir_path = tmpdir.path();
+        std::env::set_var("TX5_CACHE_DIRECTORY", tmpdir_path.as_os_str());
 
         use rand::Rng;
         let mut data = vec![0; 1024 * 1024 * 10]; // 10 MiB
@@ -280,12 +281,12 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.path.starts_with(tmpdir_path.clone()));
+        assert!(res.path.starts_with(tmpdir_path));
 
         // cleanup
         let path = res.path().to_owned();
+        std::env::remove_var("TX5_CACHE_DIRECTORY");
         drop(res);
         let _ = std::fs::remove_file(path);
-        let _ = std::fs::remove_dir(tmpdir_path);
     }
 }

--- a/crates/tx5-core/src/file_check.rs
+++ b/crates/tx5-core/src/file_check.rs
@@ -26,8 +26,6 @@ fn get_cache_dir() -> Result<std::path::PathBuf> {
     match std::env::var("TX5_CACHE_DIRECTORY") {
         Ok(cache_dir) => {
             let path = PathBuf::from(cache_dir);
-            println!("get_cache_dir TX5_CACHE_DIRECTORY={:?}", path);
-            tracing::debug!("get_cache_dir TX5_CACHE_DIRECTORY={:?}", path);
             if path.is_dir() {
                 Ok(path)
             } else {
@@ -57,17 +55,10 @@ pub fn file_check(
     file_name_ext: &str,
 ) -> Result<FileCheck> {
     let file_name = format!("{file_name_prefix}-{file_hash}{file_name_ext}");
-    println!("File check file_name={:?}", file_name);
-    tracing::debug!("File check file_name={:?}", file_name);
-
     let tmp_dir = get_cache_dir()?;
-    println!("File check tmp_dir={:?}", tmp_dir);
-    tracing::debug!("File check tmp_dir={:?}", tmp_dir);
 
     let mut pref_path = tmp_dir.clone();
     pref_path.push(&file_name);
-
-    println!("File check {:?}", pref_path);
 
     if let Ok(file) = validate(&pref_path, file_hash) {
         return Ok(FileCheck {

--- a/crates/tx5-go-pion-sys/src/lib.rs
+++ b/crates/tx5-go-pion-sys/src/lib.rs
@@ -210,7 +210,7 @@ mod dynamic_lib {
                 "tx5-go-pion-webrtc",
                 ext,
             ) {
-                Err(err) => panic!("filed to write go lib: {err:?}"),
+                Err(err) => panic!("failed to write go lib: {err:?}"),
                 Ok(lib) => lib,
             };
 


### PR DESCRIPTION
Follow up to #69 

After the changes in #77, the pion go lib was still being written to a temporary directory specified by the package `tempfile`, which got its base path from `std::env::temp_dir`. On android this would return `/data/local/tmp`, which is writable in an adb shell, but not by apps in non-rooted devices.

Now it is written to the UserCache directory specified by `app_dirs2`, or can be overridden via the env variable `TX5_CACHE_DIRECTORY`.

The env variable override lets us set the cache directory to `/data/local/tmp` for running tests on android. 