### PR TITLE
abstract tx5 backend in prep for m̶o̶c̶k̶  mem backend

### DIFF
--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -21,6 +21,7 @@ backend-webrtc-rs = [ "tx5-connection/backend-webrtc-rs" ]
 
 [dependencies]
 base64 = { workspace = true }
+futures = { workspace = true }
 influxive-otel-atomic-obs = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = [ "full" ] }

--- a/crates/tx5/src/backend.rs
+++ b/crates/tx5/src/backend.rs
@@ -1,0 +1,134 @@
+//! Backend modules usable by tx5.
+
+use std::io::Result;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+
+use crate::{Config, PubKey};
+use tx5_core::deps::serde_json;
+
+#[cfg(feature = "backend-go-pion")]
+mod go_pion;
+
+/// Backend modules usable by tx5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BackendModule {
+    #[cfg(feature = "backend-go-pion")]
+    /// The Go Pion-based backend.
+    GoPion,
+
+    #[cfg(feature = "backend-webrtc-rs")]
+    /// The Webrtc-RS-based backend.
+    WebrtcRs,
+
+    /// The mock backend.
+    Mock,
+}
+
+impl Default for BackendModule {
+    #[allow(unreachable_code)]
+    fn default() -> Self {
+        #[cfg(feature = "backend-go-pion")]
+        return Self::GoPion;
+        #[cfg(feature = "backend-webrtc-rs")]
+        return Self::WebrtcRs;
+        Self::Mock
+    }
+}
+
+impl BackendModule {
+    /// Get a default version of the module-specific config.
+    pub fn default_config(&self) -> serde_json::Value {
+        match self {
+            #[cfg(feature = "backend-go-pion")]
+            Self::GoPion => go_pion::default_config(),
+            #[cfg(feature = "backend-webrtc-rs")]
+            Self::WebrtcRs => todo!(),
+            Self::Mock => serde_json::json!({}),
+        }
+    }
+
+    /// Connect a new backend module endpoint.
+    pub async fn connect(
+        &self,
+        url: &str,
+        listener: bool,
+        config: &Arc<Config>,
+    ) -> Result<(DynBackEp, DynBackEpRecv)> {
+        match self {
+            #[cfg(feature = "backend-go-pion")]
+            Self::GoPion => go_pion::connect(config, url, listener).await,
+            #[cfg(feature = "backend-webrtc-rs")]
+            Self::WebrtcRs => todo!(),
+            Self::Mock => todo!(),
+        }
+    }
+}
+
+/// Backend connection.
+pub trait BackCon: 'static + Send + Sync {
+    /// Send data over this backend connection.
+    fn send(&self, data: Vec<u8>) -> BoxFuture<'_, Result<()>>;
+
+    /// Get the pub_key identifying this connection.
+    fn pub_key(&self) -> &PubKey;
+
+    /// Returns `true` if we successfully connected over webrtc.
+    // TODO - this isn't good encapsulation
+    fn is_using_webrtc(&self) -> bool;
+
+    /// Get connection statistics.
+    // TODO - this isn't good encapsulation
+    fn get_stats(&self) -> tx5_connection::ConnStats;
+}
+
+/// Trait-object version of backend connection.
+pub type DynBackCon = Arc<dyn BackCon + 'static + Send + Sync>;
+
+/// Backend connection receiver.
+pub trait BackConRecv: 'static + Send {
+    /// Receive data from this backend connection.
+    fn recv(&mut self) -> BoxFuture<'_, Option<Vec<u8>>>;
+}
+
+/// Trait-object version of backend connection receiver.
+pub type DynBackConRecv = Box<dyn BackConRecv + 'static + Send>;
+
+/// Pending connection.
+pub trait BackWaitCon: 'static + Send {
+    /// Wait for the connection
+    fn wait(
+        &mut self,
+        // TODO - this isn't good encapsulation
+        recv_limit: Arc<tokio::sync::Semaphore>,
+    ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecv)>>;
+
+    /// Get the pub_key identifying this connection.
+    fn pub_key(&self) -> &PubKey;
+}
+
+/// Trait-object version of backend wait con.
+pub type DynBackWaitCon = Box<dyn BackWaitCon + 'static + Send>;
+
+/// Backend endpoint.
+pub trait BackEp: 'static + Send + Sync {
+    /// Establish an outgoing connection from this backend endpoint.
+    fn connect(&self, pub_key: PubKey)
+        -> BoxFuture<'_, Result<DynBackWaitCon>>;
+
+    /// Get the pub_key identifying this endpoint.
+    fn pub_key(&self) -> &PubKey;
+}
+
+/// Trait-object version of backend endpoint.
+pub type DynBackEp = Arc<dyn BackEp + 'static + Send + Sync>;
+
+/// Backend endpoint receiver.
+pub trait BackEpRecv: 'static + Send {
+    /// Receive incoming connection from this backend endpoint.
+    fn recv(&mut self) -> BoxFuture<'_, Option<DynBackWaitCon>>;
+}
+
+/// Trait-object version of backend endpoint receiver.
+pub type DynBackEpRecv = Box<dyn BackEpRecv + 'static + Send>;

--- a/crates/tx5/src/backend.rs
+++ b/crates/tx5/src/backend.rs
@@ -55,7 +55,7 @@ impl BackendModule {
         url: &str,
         listener: bool,
         config: &Arc<Config>,
-    ) -> Result<(DynBackEp, DynBackEpRecv)> {
+    ) -> Result<(DynBackEp, DynBackEpRecvCon)> {
         match self {
             #[cfg(feature = "backend-go-pion")]
             Self::GoPion => go_pion::connect(config, url, listener).await,
@@ -87,13 +87,13 @@ pub trait BackCon: 'static + Send + Sync {
 pub type DynBackCon = Arc<dyn BackCon + 'static + Send + Sync>;
 
 /// Backend connection receiver.
-pub trait BackConRecv: 'static + Send {
+pub trait BackConRecvData: 'static + Send {
     /// Receive data from this backend connection.
     fn recv(&mut self) -> BoxFuture<'_, Option<Vec<u8>>>;
 }
 
 /// Trait-object version of backend connection receiver.
-pub type DynBackConRecv = Box<dyn BackConRecv + 'static + Send>;
+pub type DynBackConRecvData = Box<dyn BackConRecvData + 'static + Send>;
 
 /// Pending connection.
 pub trait BackWaitCon: 'static + Send {
@@ -102,7 +102,7 @@ pub trait BackWaitCon: 'static + Send {
         &mut self,
         // TODO - this isn't good encapsulation
         recv_limit: Arc<tokio::sync::Semaphore>,
-    ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecv)>>;
+    ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecvData)>>;
 
     /// Get the pub_key identifying this connection.
     fn pub_key(&self) -> &PubKey;
@@ -125,10 +125,10 @@ pub trait BackEp: 'static + Send + Sync {
 pub type DynBackEp = Arc<dyn BackEp + 'static + Send + Sync>;
 
 /// Backend endpoint receiver.
-pub trait BackEpRecv: 'static + Send {
+pub trait BackEpRecvCon: 'static + Send {
     /// Receive incoming connection from this backend endpoint.
     fn recv(&mut self) -> BoxFuture<'_, Option<DynBackWaitCon>>;
 }
 
 /// Trait-object version of backend endpoint receiver.
-pub type DynBackEpRecv = Box<dyn BackEpRecv + 'static + Send>;
+pub type DynBackEpRecvCon = Box<dyn BackEpRecvCon + 'static + Send>;

--- a/crates/tx5/src/backend/go_pion.rs
+++ b/crates/tx5/src/backend/go_pion.rs
@@ -1,0 +1,136 @@
+//! go pion backend
+
+use super::*;
+use crate::Config;
+
+struct GoCon(tx5_connection::FramedConn);
+
+impl BackCon for GoCon {
+    fn send(&self, data: Vec<u8>) -> BoxFuture<'_, Result<()>> {
+        Box::pin(async { self.0.send(data).await })
+    }
+
+    fn pub_key(&self) -> &PubKey {
+        self.0.pub_key()
+    }
+
+    fn is_using_webrtc(&self) -> bool {
+        self.0.is_using_webrtc()
+    }
+
+    fn get_stats(&self) -> tx5_connection::ConnStats {
+        self.0.get_stats()
+    }
+}
+
+struct GoConRecv(tx5_connection::FramedConnRecv);
+
+impl BackConRecv for GoConRecv {
+    fn recv(&mut self) -> BoxFuture<'_, Option<Vec<u8>>> {
+        Box::pin(async { self.0.recv().await })
+    }
+}
+
+struct GoWaitCon(
+    PubKey,
+    Option<Arc<tx5_connection::Conn>>,
+    Option<tx5_connection::ConnRecv>,
+);
+
+impl BackWaitCon for GoWaitCon {
+    fn wait(
+        &mut self,
+        recv_limit: Arc<tokio::sync::Semaphore>,
+    ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecv)>> {
+        let con = self.1.take();
+        let con_recv = self.2.take();
+        Box::pin(async move {
+            let (con, con_recv) = match (con, con_recv) {
+                (_, None) | (None, _) => {
+                    return Err(std::io::Error::other("already awaited"))
+                }
+                (Some(con), Some(con_recv)) => (con, con_recv),
+            };
+
+            con.ready().await;
+
+            let (con, con_recv) =
+                tx5_connection::FramedConn::new(con, con_recv, recv_limit)
+                    .await?;
+
+            let con: DynBackCon = Arc::new(GoCon(con));
+            let con_recv: DynBackConRecv = Box::new(GoConRecv(con_recv));
+
+            Ok((con, con_recv))
+        })
+    }
+
+    fn pub_key(&self) -> &PubKey {
+        &self.0
+    }
+}
+
+struct GoEp(tx5_connection::Hub);
+
+impl BackEp for GoEp {
+    fn connect(
+        &self,
+        pub_key: PubKey,
+    ) -> BoxFuture<'_, Result<DynBackWaitCon>> {
+        Box::pin(async {
+            let (con, con_recv) = self.0.connect(pub_key).await?;
+            let pub_key = con.pub_key().clone();
+            let wc: DynBackWaitCon =
+                Box::new(GoWaitCon(pub_key, Some(con), Some(con_recv)));
+            Ok(wc)
+        })
+    }
+
+    fn pub_key(&self) -> &PubKey {
+        self.0.pub_key()
+    }
+}
+
+struct GoEpRecv(tx5_connection::HubRecv);
+
+impl BackEpRecv for GoEpRecv {
+    fn recv(&mut self) -> BoxFuture<'_, Option<DynBackWaitCon>> {
+        Box::pin(async {
+            if let Some((con, con_recv)) = self.0.accept().await {
+                let pub_key = con.pub_key().clone();
+                let wc: DynBackWaitCon =
+                    Box::new(GoWaitCon(pub_key, Some(con), Some(con_recv)));
+                Some(wc)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+/// Get a default version of the module-specific config.
+pub fn default_config() -> serde_json::Value {
+    serde_json::json!({})
+}
+
+/// Connect a new backend based on the tx5-go-pion backend.
+pub async fn connect(
+    config: &Arc<Config>,
+    url: &str,
+    listener: bool,
+) -> Result<(DynBackEp, DynBackEpRecv)> {
+    let webrtc_config = config.initial_webrtc_config.clone().into_bytes();
+    let sig_config = tx5_connection::tx5_signal::SignalConfig {
+        listener,
+        allow_plain_text: config.signal_allow_plain_text,
+        //max_connections: config.connection_count_max as usize,
+        max_idle: config.timeout,
+        ..Default::default()
+    };
+    let (hub, hub_recv) =
+        tx5_connection::Hub::new(webrtc_config, url, Arc::new(sig_config))
+            .await?;
+    let ep: DynBackEp = Arc::new(GoEp(hub));
+    let ep_recv: DynBackEpRecv = Box::new(GoEpRecv(hub_recv));
+    Ok((ep, ep_recv))
+}

--- a/crates/tx5/src/backend/go_pion.rs
+++ b/crates/tx5/src/backend/go_pion.rs
@@ -96,14 +96,11 @@ struct GoEpRecv(tx5_connection::HubRecv);
 impl BackEpRecv for GoEpRecv {
     fn recv(&mut self) -> BoxFuture<'_, Option<DynBackWaitCon>> {
         Box::pin(async {
-            if let Some((con, con_recv)) = self.0.accept().await {
-                let pub_key = con.pub_key().clone();
-                let wc: DynBackWaitCon =
-                    Box::new(GoWaitCon(pub_key, Some(con), Some(con_recv)));
-                Some(wc)
-            } else {
-                None
-            }
+            let (con, con_recv) = self.0.accept().await?;
+            let pub_key = con.pub_key().clone();
+            let wc: DynBackWaitCon =
+                Box::new(GoWaitCon(pub_key, Some(con), Some(con_recv)));
+            Some(wc)
         })
     }
 }

--- a/crates/tx5/src/config.rs
+++ b/crates/tx5/src/config.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use tx5_core::deps::serde_json;
 
 /// Tx5 endpoint configuration.
 pub struct Config {
@@ -40,6 +41,15 @@ pub struct Config {
     /// set the callbacks here, otherwise no preflight will
     /// be sent nor validated. Default: None.
     pub preflight: Option<(PreflightSendCb, PreflightCheckCb)>,
+
+    /// The backend connection module to use.
+    /// For the most part you should just leave this at the default.
+    pub backend_module: crate::backend::BackendModule,
+
+    /// The backend module config to use.
+    /// For the most part you should just leave this set at `None`,
+    /// to get the default backend config.
+    pub backend_module_config: Option<serde_json::Value>,
 }
 
 impl std::fmt::Debug for Config {
@@ -81,6 +91,8 @@ impl Default for Config {
             backoff_start: std::time::Duration::from_secs(5),
             backoff_max: std::time::Duration::from_secs(60),
             preflight: None,
+            backend_module: crate::backend::BackendModule::default(),
+            backend_module_config: None,
         }
     }
 }

--- a/crates/tx5/src/lib.rs
+++ b/crates/tx5/src/lib.rs
@@ -54,6 +54,9 @@ pub type PreflightCheckCb = Arc<
         + Sync,
 >;
 
+pub mod backend;
+use backend::*;
+
 mod config;
 pub use config::*;
 

--- a/crates/tx5/src/sig.rs
+++ b/crates/tx5/src/sig.rs
@@ -83,7 +83,7 @@ async fn connect_loop(
     sig_url: SigUrl,
     listener: bool,
     mut resp_url: Option<tokio::sync::oneshot::Sender<PeerUrl>>,
-) -> (DynBackEp, DynBackEpRecv) {
+) -> (DynBackEp, DynBackEpRecvCon) {
     tracing::debug!(
         target: "NETAUDIT",
         ?config,


### PR DESCRIPTION
- Actual mock backend PR to follow.
- There are a couple apis that aren't great encapsulation for the abstraction at this level, but in the name of expediency, I've just called them out in the code for now to be addressed at a later date.
- I'd love for the mock config to be configurable all the way up into the holochain conductor config, so I went with a generic `serde_json::Value` because those items will not be relevant to any other backends, but we need a shared abstraction. I'm happy to have feedback / suggestions of different ways to do this.