### PR TITLE
build: non-vendored datachannel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_build"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e361fae2caf9758164b24da3eedd7f7d7451be30d90d8e7b5d2be29a2f0cf5b"
+checksum = "27f8638c97fbd79cc6fc80b616e0e74b49bac21014faed590bbc89b7e2676c90"
 dependencies = [
  "cc",
  "cpp_common",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_common"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1a2532e4ed4ea13031c13bc7bc0dbca4aae32df48e9d77f0d1e743179f2ea1"
+checksum = "25fcfea2ee05889597d35e986c2ad0169694320ae5cc8f6d2640a4bb8a884560"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -651,9 +651,9 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "datachannel"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c0a2f521db946447fcea36f1e6a2634633568e4f32dc1384941e455763471"
+checksum = "6a9104be65808f5ba4cae77831aa5b1874a64de31ceed449db37897910d0d72e"
 dependencies = [
  "datachannel-sys",
  "derivative",
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "datachannel-sys"
-version = "0.21.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b2f94958fd5ba1ba19d88db9757906ba7849c34cc6a1e535e91c3c8cad831"
+checksum = "2ead19df10c4e46d8d4b33de06c6224dcafc98bad666ac62629d363675866cae"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,14 @@ bit_field = "0.10.2"
 bytes = "1.4.0"
 clap = { version = "4.4.6", features = [ "derive", "wrap_help" ] }
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
-datachannel = { version = "0.13.1", default-features = false, features = [ "tracing", "vendored" ] }
+# datachannel dependencies with different features; make sure to update both
+# datachannel that depends on system openssl
+datachannel = { version = "0.14.0", default-features = false, features = [ "tracing" ] }
+# datachannel with vendored openssl
+datachannel-openssl = { package = "datachannel", version = "0.14.0", default-features = false, features = [
+  "tracing",
+  "vendored",
+] }
 dirs = "5.0.0"
 dunce = "1.0.3"
 futures = "0.3.28"

--- a/crates/tx5-connection/Cargo.toml
+++ b/crates/tx5-connection/Cargo.toml
@@ -16,6 +16,9 @@ default = [ "backend-go-pion" ]
 # use the libdatachannel crate as the webrtc backend
 backend-libdatachannel = [ "dep:datachannel" ]
 
+# use the libdatachannel crate with vendored openssl as the webrtc backend
+backend-libdatachannel-openssl = [ "dep:datachannel-openssl" ]
+
 # use the tx5-go-pion crate as the webrtc backend
 backend-go-pion = [ "dep:tx5-go-pion" ]
 
@@ -25,6 +28,7 @@ backend-webrtc-rs = [ ]
 [dependencies]
 bit_field = { workspace = true }
 datachannel = { workspace = true, optional = true }
+datachannel-openssl= { workspace = true, optional = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tx5-connection/src/config.rs
+++ b/crates/tx5-connection/src/config.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Copy)]
 pub enum BackendModule {
     /// Use the libdatachannel backend.
-    #[cfg(feature = "backend-libdatachannel")]
+    #[cfg(any(
+        feature = "backend-libdatachannel",
+        feature = "backend-libdatachannel-openssl"
+    ))]
     LibDataChannel,
 
     /// Use the go pion backend.
@@ -15,7 +18,10 @@ pub enum BackendModule {
 impl Default for BackendModule {
     #[allow(unreachable_code)]
     fn default() -> Self {
-        #[cfg(feature = "backend-libdatachannel")]
+        #[cfg(any(
+            feature = "backend-libdatachannel",
+            feature = "backend-libdatachannel-openssl"
+        ))]
         return Self::LibDataChannel;
         #[cfg(feature = "backend-go-pion")]
         Self::GoPion

--- a/crates/tx5-connection/src/webrtc.rs
+++ b/crates/tx5-connection/src/webrtc.rs
@@ -20,7 +20,10 @@ pub trait Webrtc: 'static + Send + Sync {
 
 pub type DynWebrtc = Arc<dyn Webrtc + 'static + Send + Sync>;
 
-#[cfg(feature = "backend-libdatachannel")]
+#[cfg(any(
+    feature = "backend-libdatachannel",
+    feature = "backend-libdatachannel-openssl"
+))]
 mod libdatachannel;
 
 #[cfg(feature = "backend-go-pion")]
@@ -33,7 +36,10 @@ pub fn new_backend_module(
     send_buffer: usize,
 ) -> (DynWebrtc, CloseRecv<WebrtcEvt>) {
     match module {
-        #[cfg(feature = "backend-libdatachannel")]
+        #[cfg(any(
+            feature = "backend-libdatachannel",
+            feature = "backend-libdatachannel-openssl"
+        ))]
         BackendModule::LibDataChannel => {
             libdatachannel::Webrtc::new(is_polite, config, send_buffer)
         }

--- a/crates/tx5-connection/src/webrtc/libdatachannel.rs
+++ b/crates/tx5-connection/src/webrtc/libdatachannel.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::{AbortTask, CloseRecv, CloseSend};
+#[cfg(feature = "backend-libdatachannel-openssl")]
+use datachannel_openssl as datachannel;
 use std::io::{Error, Result};
 
 type MapErr<E, F> = Box<dyn FnOnce(E) -> F>;

--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -16,6 +16,9 @@ default = [ "backend-go-pion" ]
 # use the libdatachannel crate as the webrtc backend
 backend-libdatachannel = [ "tx5-connection/backend-libdatachannel" ]
 
+# use the libdatachannel crate with vendored openssl as the webrtc backend
+backend-libdatachannel-openssl = [ "tx5-connection/backend-libdatachannel-openssl" ]
+
 # use the tx5-go-pion crate as the webrtc backend
 backend-go-pion = [ "tx5-connection/backend-go-pion" ]
 


### PR DESCRIPTION
This duplicates the `datachannel` dependency to make it available both with and without a vendored openssl. Kitsune2 cannot be built in nix with the vendored feature, so this is the workaround.

I couldn't self-reference from the renamed dependency `datachannel-openssl` to `datachannel` in the workspace to reuse the version. Therefore this ended up being a duplicate entry.