### PR TITLE
feat!: Make configuration typed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1092,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1988,6 +1995,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "indexmap 1.9.3",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2068,17 @@ name = "serde_derive"
 version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2549,6 +2592,7 @@ dependencies = [
  "futures",
  "rand",
  "sbd-server",
+ "schemars",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tx5-signal = { version = "0.3.4", path = "crates/tx5-signal" }
 tx5 = { version = "0.3.4", path = "crates/tx5" }
 url = { version = "2.3.1", features = [ "serde" ] }
 zip = { version = "0.6.4", default-features = false, features = [ "deflate" ] }
+schemars = { version = "0.8.22", features = ["preserve_order"] }
 
 #[patch.crates-io]
 #sbd-e2e-crypto-client = { path = "../sbd/rust/sbd-e2e-crypto-client" }

--- a/crates/tx5-connection/Cargo.toml
+++ b/crates/tx5-connection/Cargo.toml
@@ -24,6 +24,9 @@ backend-go-pion = [ "dep:tx5-go-pion" ]
 # use the webrtc-rs crate as the webrtc backend
 backend-webrtc-rs = [ ]
 
+# make a schema available for configuration types
+schema = [ "dep:schemars" ]
+
 [dependencies]
 bit_field = { workspace = true }
 datachannel = { workspace = true, optional = true }
@@ -35,6 +38,7 @@ tracing = { workspace = true }
 tx5-core = { workspace = true }
 tx5-signal = { workspace = true }
 tx5-go-pion = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/tx5-connection/src/config.rs
+++ b/crates/tx5-connection/src/config.rs
@@ -37,6 +37,15 @@ pub struct HubConfig {
     pub test_fail_webrtc: bool,
 }
 
+/// The type of credential to use for ICE servers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CredentialType {
+    /// A password is used for authentication.
+    #[default]
+    Password,
+}
+
 /// Configuration for a group of ICE servers.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -44,6 +53,29 @@ pub struct HubConfig {
 pub struct IceServers {
     /// The ICE server URLs to use for discovering external candidates.
     pub urls: Vec<String>,
+
+    /// The username to use for authentication.
+    #[serde(default)]
+    pub username: Option<String>,
+    
+    /// The credential to use for authentication.
+    #[serde(default)]
+    pub credential: Option<String>,
+    
+    /// The credential type to use for authentication.
+    #[serde(default)]
+    pub credential_type: Option<CredentialType>,
+}
+
+/// ICE transport policy.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum TransportPolicy {
+    /// Any type of candidate can be used.
+    #[default]
+    All,
+    /// Only media relay candidates can be used.
+    Relay,
 }
 
 /// WebRTC config.
@@ -56,6 +88,10 @@ pub struct IceServers {
 pub struct WebRtcConfig {
     /// A list of ICE servers configurations.
     pub ice_servers: Vec<IceServers>,
+
+    /// The ICE transport policy to use.
+    #[serde(default)]
+    pub ice_transport_policy: TransportPolicy,
 }
 
 #[cfg(feature = "backend-go-pion")]

--- a/crates/tx5-connection/src/config.rs
+++ b/crates/tx5-connection/src/config.rs
@@ -57,11 +57,11 @@ pub struct IceServers {
     /// The username to use for authentication.
     #[serde(default)]
     pub username: Option<String>,
-    
+
     /// The credential to use for authentication.
     #[serde(default)]
     pub credential: Option<String>,
-    
+
     /// The credential type to use for authentication.
     #[serde(default)]
     pub credential_type: Option<CredentialType>,

--- a/crates/tx5-connection/src/conn.rs
+++ b/crates/tx5-connection/src/conn.rs
@@ -67,20 +67,14 @@ impl Conn {
     }
 
     pub(crate) fn priv_new(
-        webrtc_config: Vec<u8>,
+        webrtc_config: WebRtcConfig,
         is_polite: bool,
         pub_key: PubKey,
         client: Weak<tx5_signal::SignalConnection>,
         config: Arc<HubConfig>,
         hub_cmd_send: tokio::sync::mpsc::Sender<HubCmd>,
     ) -> (Arc<Self>, ConnRecv, CloseSend<ConnCmd>) {
-        netaudit!(
-            DEBUG,
-            webrtc_config = String::from_utf8_lossy(&webrtc_config).to_string(),
-            ?pub_key,
-            ?is_polite,
-            a = "open",
-        );
+        netaudit!(DEBUG, ?webrtc_config, ?pub_key, ?is_polite, a = "open",);
 
         let is_webrtc = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let send_msg_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -244,7 +238,7 @@ impl TaskCore {
 
 async fn con_task(
     is_polite: bool,
-    webrtc_config: Vec<u8>,
+    webrtc_config: WebRtcConfig,
     mut task_core: TaskCore,
 ) {
     // first process the handshake
@@ -380,7 +374,7 @@ enum AttemptWebrtcResult {
 
 async fn con_task_attempt_webrtc(
     is_polite: bool,
-    webrtc_config: Vec<u8>,
+    webrtc_config: WebRtcConfig,
     mut task_core: TaskCore,
 ) -> AttemptWebrtcResult {
     use AttemptWebrtcResult::*;
@@ -395,7 +389,7 @@ async fn con_task_attempt_webrtc(
     let (webrtc, webrtc_recv) = webrtc::new_backend_module(
         task_core.config.backend_module,
         is_polite,
-        webrtc_config.clone(),
+        webrtc_config,
         // MAYBE - make this configurable
         4096,
     );

--- a/crates/tx5-connection/src/hub.rs
+++ b/crates/tx5-connection/src/hub.rs
@@ -24,7 +24,7 @@ impl HubMap {
 }
 
 async fn hub_map_assert(
-    webrtc_config: &Arc<Mutex<Vec<u8>>>,
+    webrtc_config: &Arc<Mutex<WebRtcConfig>>,
     is_polite: bool,
     pub_key: PubKey,
     map: &mut HubMap,
@@ -99,7 +99,7 @@ impl HubRecv {
 
 /// A signal server connection from which we can establish tx5 connections.
 pub struct Hub {
-    webrtc_config: Arc<Mutex<Vec<u8>>>,
+    webrtc_config: Arc<Mutex<WebRtcConfig>>,
     client: Arc<tx5_signal::SignalConnection>,
     hub_cmd_send: tokio::sync::mpsc::Sender<HubCmd>,
     task_list: Vec<tokio::task::JoinHandle<()>>,
@@ -118,7 +118,7 @@ impl Hub {
     /// Note, if this is not a "listener" client,
     /// you do not need to ever call accept.
     pub async fn new(
-        webrtc_config: Vec<u8>,
+        webrtc_config: WebRtcConfig,
         url: &str,
         config: Arc<HubConfig>,
     ) -> Result<(Self, HubRecv)> {
@@ -276,10 +276,11 @@ impl Hub {
         }
     }
 
-    /// Alter the webrtc_config at runtime. This will affect all future
-    /// new outgoing connections, and all connections accepted on the
+    /// Alter the webrtc_config at runtime.
+    ///
+    /// This will affect all future new outgoing connections, and all connections accepted on the
     /// receiver. It will not affect any connections already established.
-    pub fn set_webrtc_config(&self, webrtc_config: Vec<u8>) {
+    pub fn set_webrtc_config(&self, webrtc_config: WebRtcConfig) {
         *self.webrtc_config.lock().unwrap() = webrtc_config;
     }
 }

--- a/crates/tx5-connection/src/test.rs
+++ b/crates/tx5-connection/src/test.rs
@@ -47,7 +47,7 @@ impl TestSrv {
 
         for addr in self.server.bind_addrs() {
             if let Ok(r) = Hub::new(
-                b"{}".to_vec(),
+                WebRtcConfig::default(),
                 &format!("ws://{addr}"),
                 Arc::new(HubConfig {
                     backend_module: BackendModule::default(),

--- a/crates/tx5-connection/src/webrtc.rs
+++ b/crates/tx5-connection/src/webrtc.rs
@@ -1,4 +1,4 @@
-use crate::{BackendModule, CloseRecv};
+use crate::{BackendModule, CloseRecv, WebRtcConfig};
 use futures::future::BoxFuture;
 use std::io::Result;
 use std::sync::Arc;
@@ -29,7 +29,7 @@ mod go_pion;
 pub fn new_backend_module(
     module: BackendModule,
     is_polite: bool,
-    config: Vec<u8>,
+    config: WebRtcConfig,
     send_buffer: usize,
 ) -> (DynWebrtc, CloseRecv<WebrtcEvt>) {
     match module {

--- a/crates/tx5-connection/src/webrtc/go_pion.rs
+++ b/crates/tx5-connection/src/webrtc/go_pion.rs
@@ -27,7 +27,7 @@ impl Webrtc {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
         is_polite: bool,
-        config: Vec<u8>,
+        config: WebRtcConfig,
         send_buffer: usize,
     ) -> (DynWebrtc, CloseRecv<WebrtcEvt>) {
         let (mut cmd_send, cmd_recv) = CloseSend::sized_channel(1024);
@@ -94,7 +94,7 @@ impl super::Webrtc for Webrtc {
 
 async fn task(
     is_polite: bool,
-    config: Vec<u8>,
+    config: WebRtcConfig,
     send_buffer: usize,
     mut evt_send: CloseSend<WebrtcEvt>,
     cmd_send: CloseSend<Cmd>,
@@ -102,6 +102,7 @@ async fn task(
 ) -> Result<()> {
     evt_send.set_close_on_drop(true);
 
+    let config = config.to_go_buf()?;
     let (peer, mut peer_evt) = tx5_go_pion::PeerConnection::new(config).await?;
 
     let mut cmd_send2 = cmd_send.clone();

--- a/crates/tx5-connection/src/webrtc/libdatachannel.rs
+++ b/crates/tx5-connection/src/webrtc/libdatachannel.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{AbortTask, CloseRecv, CloseSend};
+use datachannel::TransportPolicy;
 use std::io::{Error, Result};
 
 type MapErr<E, F> = Box<dyn FnOnce(E) -> F>;
@@ -232,6 +233,10 @@ async fn task_err(
             .cloned()
             .collect::<Vec<_>>(),
     )
+    .ice_transport_policy(match config.ice_transport_policy {
+        crate::config::TransportPolicy::All => TransportPolicy::All,
+        crate::config::TransportPolicy::Relay => TransportPolicy::Relay,
+    })
     .port_range_begin(init_config.ephemeral_udp_port_min)
     .port_range_end(init_config.ephemeral_udp_port_max);
     let mut peer =

--- a/crates/tx5-connection/src/webrtc/libdatachannel.rs
+++ b/crates/tx5-connection/src/webrtc/libdatachannel.rs
@@ -98,7 +98,7 @@ impl Webrtc {
     #[allow(clippy::needless_return)]
     pub fn new(
         is_polite: bool,
-        config: Vec<u8>,
+        config: WebRtcConfig,
         send_buffer: usize,
     ) -> (DynWebrtc, CloseRecv<WebrtcEvt>) {
         static INIT_TRACING: std::sync::Once = std::sync::Once::new();
@@ -197,7 +197,7 @@ impl super::Webrtc for Webrtc {
 
 async fn task(
     is_polite: bool,
-    config: Vec<u8>,
+    config: WebRtcConfig,
     send_buffer: usize,
     evt_send: CloseSend<WebrtcEvt>,
     cmd_send: CloseSend<Cmd>,
@@ -213,7 +213,7 @@ async fn task(
 
 async fn task_err(
     is_polite: bool,
-    config: Vec<u8>,
+    config: WebRtcConfig,
     send_buffer: usize,
     mut evt_send: CloseSend<WebrtcEvt>,
     cmd_send: CloseSend<Cmd>,
@@ -221,35 +221,19 @@ async fn task_err(
 ) -> Result<()> {
     evt_send.set_close_on_drop(true);
 
-    #[derive(Debug, Default, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct U {
-        pub urls: Vec<String>,
-    }
-
-    #[derive(Debug, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct C {
-        #[serde(default)]
-        pub ice_servers: Vec<U>,
-    }
-
-    let mut ice = Vec::new();
-    match serde_json::from_slice::<C>(&config) {
-        Ok(mut c) => {
-            for mut u in c.ice_servers.drain(..) {
-                ice.append(&mut u.urls);
-            }
-        }
-        Err(err) => tracing::error!(?err, "failed to parse iceServers"),
-    }
-
     let init_config = tx5_core::Tx5InitConfig::get();
 
     // TODO - max_message_size?
-    let config = datachannel::RtcConfig::new::<String>(&ice)
-        .port_range_begin(init_config.ephemeral_udp_port_min)
-        .port_range_end(init_config.ephemeral_udp_port_max);
+    let config = datachannel::RtcConfig::new::<String>(
+        &config
+            .ice_servers
+            .iter()
+            .flat_map(|s| s.urls.iter())
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .port_range_begin(init_config.ephemeral_udp_port_min)
+    .port_range_end(init_config.ephemeral_udp_port_max);
     let mut peer =
         datachannel::RtcPeerConnection::new(&config, Pch(cmd_send.clone()))
             .map_err(map_err("constructing peer connection"))?;

--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -25,6 +25,9 @@ backend-go-pion = [ "tx5-connection/backend-go-pion" ]
 # use the webrtc-rs crate as the webrtc backend
 backend-webrtc-rs = [ "tx5-connection/backend-webrtc-rs" ]
 
+# make a schema available for configuration types
+schema = [ "tx5-connection/schema" ]
+
 [dependencies]
 base64 = { workspace = true }
 futures = { workspace = true }

--- a/crates/tx5/src/backend/be_tx5_connection.rs
+++ b/crates/tx5/src/backend/be_tx5_connection.rs
@@ -121,7 +121,7 @@ pub async fn connect(
     url: &str,
     listener: bool,
 ) -> Result<(DynBackEp, DynBackEpRecvCon)> {
-    let webrtc_config = config.initial_webrtc_config.clone().into_bytes();
+    let webrtc_config = config.initial_webrtc_config.clone();
     let sig_config = tx5_connection::tx5_signal::SignalConfig {
         listener,
         allow_plain_text: config.signal_allow_plain_text,

--- a/crates/tx5/src/config.rs
+++ b/crates/tx5/src/config.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use tx5_connection::WebRtcConfig;
 use tx5_core::deps::serde_json;
 
 /// Tx5 endpoint configuration.
@@ -6,8 +7,8 @@ pub struct Config {
     /// Allow plain text (non-tls) signal server connections.
     pub signal_allow_plain_text: bool,
 
-    /// Initial webrtc peer connection config. Defaults to `{}`.
-    pub initial_webrtc_config: String,
+    /// Initial webrtc peer connection config.
+    pub initial_webrtc_config: WebRtcConfig,
 
     /// Maximum count of open connections. Default 4096.
     pub connection_count_max: u32,
@@ -19,7 +20,7 @@ pub struct Config {
     pub recv_buffer_bytes_max: u32,
 
     /// Maximum receive message reconstruction bytes in memory
-    /// (accross entire endpoint). Default 512 MiB.
+    /// (across entire endpoint). Default 512 MiB.
     pub incoming_message_bytes_max: u32,
 
     /// Maximum size of an individual message. Default 16 MiB.
@@ -80,7 +81,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             signal_allow_plain_text: false,
-            initial_webrtc_config: "{}".to_string(),
+            initial_webrtc_config: WebRtcConfig::default(),
             connection_count_max: 4096,
             send_buffer_bytes_max: 64 * 1024,
             recv_buffer_bytes_max: 64 * 1024,
@@ -91,7 +92,7 @@ impl Default for Config {
             backoff_start: std::time::Duration::from_secs(5),
             backoff_max: std::time::Duration::from_secs(60),
             preflight: None,
-            backend_module: crate::backend::BackendModule::default(),
+            backend_module: BackendModule::default(),
             backend_module_config: None,
         }
     }

--- a/crates/tx5/src/lib.rs
+++ b/crates/tx5/src/lib.rs
@@ -25,6 +25,8 @@
 #[cfg(feature = "backend-go-pion")]
 pub use tx5_connection::Tx5InitConfig;
 
+pub use tx5_connection::{IceServers, WebRtcConfig};
+
 use std::collections::HashMap;
 use std::io::{Error, Result};
 use std::sync::{Arc, Mutex, Weak};
@@ -73,8 +75,6 @@ pub mod stats;
 
 #[cfg(test)]
 mod test;
-
-//pub use tx5_core::Tx5InitConfig;
 
 // #[cfg(test)]
 // mod test_behavior;


### PR DESCRIPTION
The JSON configuration matching the [MDN recommendation](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#configuration) really only worked with the Go pion backend. Datachannel uses a different configuration.

I'm proposing only exposing what is common. It does restrict the options that can be passed to the Go backend and requires an API change to add new options but I think what is gained by making the API clearer is worth that tradeoff.