### PR TITLE
chore: Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "base64",
  "criterion",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-connection"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "bit_field",
  "datachannel",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "app_dirs2",
  "base64",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-demo"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "base64",
  "clap",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "futures",
  "tokio",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "Inflector",
  "base64",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "base64",
  "dirs",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-online"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "once_cell",
  "rand",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "rand",
  "sbd-e2e-crypto-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 
 [workspace.dependencies]
@@ -47,13 +47,13 @@ tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 trust-dns-resolver = "0.22.0"
-tx5-connection = { version = "0.3.4", default-features = false, path = "crates/tx5-connection" }
-tx5-core = { version = "0.3.4", default-features = false, path = "crates/tx5-core" }
-tx5-go-pion-turn = { version = "0.3.4", path = "crates/tx5-go-pion-turn" }
-tx5-go-pion-sys = { version = "0.3.4", path = "crates/tx5-go-pion-sys" }
-tx5-go-pion = { version = "0.3.4", path = "crates/tx5-go-pion" }
-tx5-signal = { version = "0.3.4", path = "crates/tx5-signal" }
-tx5 = { version = "0.3.4", path = "crates/tx5" }
+tx5-connection = { version = "0.4.0", default-features = false, path = "crates/tx5-connection" }
+tx5-core = { version = "0.4.0", default-features = false, path = "crates/tx5-core" }
+tx5-go-pion-turn = { version = "0.4.0", path = "crates/tx5-go-pion-turn" }
+tx5-go-pion-sys = { version = "0.4.0", path = "crates/tx5-go-pion-sys" }
+tx5-go-pion = { version = "0.4.0", path = "crates/tx5-go-pion" }
+tx5-signal = { version = "0.4.0", path = "crates/tx5-signal" }
+tx5 = { version = "0.4.0", path = "crates/tx5" }
 url = { version = "2.3.1", features = [ "serde" ] }
 zip = { version = "0.6.4", default-features = false, features = [ "deflate" ] }
 schemars = { version = "0.8.22", features = ["preserve_order"] }


### PR DESCRIPTION
Since the configuration change breaks the interface, I suggest bumping the minor version. 

I've created a `release-0.3` branch to maintain 0.3 if we need to