### PR TITLE
feat: Get connected URLs from the endpoint

### DIFF
--- a/crates/tx5-go-pion-sys/src/lib.rs
+++ b/crates/tx5-go-pion-sys/src/lib.rs
@@ -315,7 +315,6 @@ impl Api {
                     let msg =
                         std::slice::from_raw_parts(slot_b as *const u8, slot_c);
                     let msg = String::from_utf8_lossy(msg);
-                    println!("Got a trace message: {msg}");
                     match slot_a {
                         1 => tracing::trace!("{}", msg),
                         2 => tracing::debug!("{}", msg),

--- a/crates/tx5-go-pion-sys/src/lib.rs
+++ b/crates/tx5-go-pion-sys/src/lib.rs
@@ -315,6 +315,7 @@ impl Api {
                     let msg =
                         std::slice::from_raw_parts(slot_b as *const u8, slot_c);
                     let msg = String::from_utf8_lossy(msg);
+                    println!("Got a trace message: {msg}");
                     match slot_a {
                         1 => tracing::trace!("{}", msg),
                         2 => tracing::debug!("{}", msg),

--- a/crates/tx5/src/ep.rs
+++ b/crates/tx5/src/ep.rs
@@ -292,6 +292,17 @@ impl Endpoint {
             .collect()
     }
 
+    /// Get the list of peers (PeerUrls) that this endpoint is currently connected to.
+    pub fn get_connected_peer_addresses(&self) -> Vec<PeerUrl> {
+        self.inner
+            .lock()
+            .unwrap()
+            .peer_map
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+    }
+
     /// Get stats.
     pub fn get_stats(&self) -> stats::Stats {
         let backend = match self.config.backend_module {


### PR DESCRIPTION
Supporting change for closing connections in K2. The only other option was to get peer ids through the stats method. But then I'd have to carefully reconstruct URLs and potentially make a mess with multiple signal servers being in use. Better to just expose this I think.