### PR TITLE
chore: Fix feature for force_static_link and force_dynamic_link clash, just warn instead of failing

### DIFF
--- a/crates/tx5-go-pion-sys/build.rs
+++ b/crates/tx5-go-pion-sys/build.rs
@@ -57,9 +57,10 @@ impl Default for Target {
 
         if std::env::var("CARGO_FEATURE_FORCE_STATIC_LINK").is_ok() {
             if link_type_forced {
-                panic!("force_static_link and force_dynamic_link cannot both be specified");
+                println!("cargo:warning=force_static_link and force_dynamic_link should not both be specified, defaulting to dynamic link");
+            } else {
+                link_type = LinkType::Static;
             }
-            link_type = LinkType::Static;
         }
 
         // allow these cfgs in check


### PR DESCRIPTION
This is a user error and as such can be a warning. This is better than having a feature clash that prevents us properly verifying the crate on release.