### PR TITLE
chore: Add a new signal integration test and refactor some nearly-duplicated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "criterion",
  "futures",
  "influxive-otel-atomic-obs",
+ "rustls",
  "sbd-server",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 trust-dns-resolver = "0.23"
+rustls = "0.23"
 tx5-connection = { version = "0.4.4", default-features = false, path = "crates/tx5-connection" }
 tx5-core = { version = "0.4.4", default-features = false, path = "crates/tx5-core" }
 tx5-go-pion-turn = { version = "0.4.4", path = "crates/tx5-go-pion-turn" }

--- a/crates/tx5-connection/src/framed.rs
+++ b/crates/tx5-connection/src/framed.rs
@@ -64,7 +64,7 @@ impl FramedConn {
         let (cmd_send, mut cmd_recv) = tokio::sync::mpsc::channel(32);
         let (msg_send, msg_recv) = tokio::sync::mpsc::channel(32);
 
-        // set up the recieve to just feed straight into the cmd task
+        // set up the receive to just feed straight into the cmd task
         let cmd_send2 = cmd_send.clone();
         let recv_task = tokio::task::spawn(async move {
             while let Some(msg) = conn_recv.recv().await {
@@ -104,6 +104,7 @@ impl FramedConn {
                                     a = "recv_framed",
                                 );
                                 if msg_send.send(msg).await.is_err() {
+                                    tracing::info!("FramedConnRecv closed, stopping cmd task");
                                     break;
                                 }
                             }

--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -50,6 +50,7 @@ sbd-server = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 tx5 = { path = ".", features = [ "test-utils" ] }
+rustls = { workspace = true }
 
 [[bench]]
 name = "throughput"

--- a/crates/tx5/tests/tests/mod.rs
+++ b/crates/tx5/tests/tests/mod.rs
@@ -1,3 +1,58 @@
+use std::sync::Arc;
+use tx5::{Endpoint, EndpointRecv, PeerUrl};
+
 mod events;
 mod multi_sig;
+mod relay_over_sig;
 mod stress;
+
+async fn sbd() -> sbd_server::SbdServer {
+    let config = sbd_server::Config {
+        bind: vec!["127.0.0.1:0".to_string(), "[::1]:0".to_string()],
+        limit_clients: 100,
+        disable_rate_limiting: true,
+        ..Default::default()
+    };
+    sbd_with_config(config).await
+}
+
+async fn sbd_with_config(
+    mut config: sbd_server::Config,
+) -> sbd_server::SbdServer {
+    // Always configure the bind addresses for tests
+    config.bind = vec!["127.0.0.1:0".to_string(), "[::1]:0".to_string()];
+    sbd_server::SbdServer::new(Arc::new(config)).await.unwrap()
+}
+
+async fn ep(s: &sbd_server::SbdServer) -> (PeerUrl, Endpoint, EndpointRecv) {
+    let config = tx5::Config {
+        signal_allow_plain_text: true, // Always allow plain text for tests
+        ..Default::default()
+    };
+
+    ep_with_config(s, config).await
+}
+
+async fn ep_with_config(
+    s: &sbd_server::SbdServer,
+    mut config: tx5::Config,
+) -> (PeerUrl, Endpoint, EndpointRecv) {
+    // Always allow plain text for tests
+    config.signal_allow_plain_text = true;
+
+    let (ep, recv) = Endpoint::new(Arc::new(config));
+    let sig = format!("ws://{}", s.bind_addrs()[0]);
+    let peer_url = ep.listen(tx5::SigUrl::parse(sig).unwrap()).await.unwrap();
+    (peer_url, ep, recv)
+}
+
+fn enable_tracing() {
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::from_default_env(),
+        )
+        .with_file(true)
+        .with_line_number(true)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}

--- a/crates/tx5/tests/tests/multi_sig.rs
+++ b/crates/tx5/tests/tests/multi_sig.rs
@@ -1,27 +1,4 @@
-use std::sync::Arc;
-
-async fn sbd() -> sbd_server::SbdServer {
-    let config = sbd_server::Config {
-        bind: vec!["127.0.0.1:0".to_string(), "[::1]:0".to_string()],
-        limit_clients: 100,
-        disable_rate_limiting: true,
-        ..Default::default()
-    };
-    sbd_server::SbdServer::new(Arc::new(config)).await.unwrap()
-}
-
-async fn ep(
-    s: &sbd_server::SbdServer,
-) -> (tx5::PeerUrl, tx5::Endpoint, tx5::EndpointRecv) {
-    let config = tx5::Config {
-        signal_allow_plain_text: true,
-        ..Default::default()
-    };
-    let (ep, recv) = tx5::Endpoint::new(Arc::new(config));
-    let sig = format!("ws://{}", s.bind_addrs()[0]);
-    let peer_url = ep.listen(tx5::SigUrl::parse(sig).unwrap()).await.unwrap();
-    (peer_url, ep, recv)
-}
+use crate::tests::{ep, sbd};
 
 async fn check_msg(
     msg: &str,

--- a/crates/tx5/tests/tests/relay_over_sig.rs
+++ b/crates/tx5/tests/tests/relay_over_sig.rs
@@ -1,0 +1,102 @@
+use crate::tests::{enable_tracing, ep_with_config, sbd_with_config};
+use tokio::time::Instant;
+use tx5::PeerUrl;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn relay_over_sig() {
+    enable_tracing();
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let sig = sbd_with_config(sbd_server::Config {
+        disable_rate_limiting: false,
+        limit_ip_kbps: 100_000,
+        limit_ip_byte_burst: 26000000,
+        ..Default::default()
+    })
+    .await;
+
+    let (p1, e1, mut r1) = ep_with_config(
+        &sig,
+        tx5::Config {
+            danger_force_signal_relay: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let (p2, e2, mut r2) = ep_with_config(
+        &sig,
+        tx5::Config {
+            danger_force_signal_relay: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Now we should have two endpoints connected to the same signal server which rely on relaying
+    // messages over the signal server.
+
+    e1.send(p2.clone(), b"hello".to_vec()).await.unwrap();
+    e2.send(p1.clone(), b"world".to_vec()).await.unwrap();
+
+    let msg = receive_next_message_from(&mut r1, p2.clone()).await;
+    assert_eq!("world", String::from_utf8_lossy(&msg));
+
+    let msg = receive_next_message_from(&mut r2, p1.clone()).await;
+    assert_eq!("hello", String::from_utf8_lossy(&msg));
+
+    // Now we should be able to send larger messages, up to the maximum size of data we normally
+    // expect to be able to send over a WebRTC connection.
+
+    let large_msg = vec![97; 1024 * 500]; // 500 KiB of data
+
+    e1.send(p2.clone(), large_msg.clone()).await.unwrap();
+    let msg = receive_next_message_from(&mut r2, p1.clone()).await;
+    assert_eq!(large_msg, msg);
+
+    e2.send(p1.clone(), large_msg.clone()).await.unwrap();
+    let msg = receive_next_message_from(&mut r1, p2.clone()).await;
+    assert_eq!(large_msg, msg);
+
+    // Send a batch of large messages
+
+    let end = Instant::now() + std::time::Duration::from_secs(60);
+    for _ in 0..20 {
+        e1.send(p2.clone(), large_msg.clone()).await.unwrap();
+    }
+
+    // Should be able to receive all of them within the timeout
+    tokio::time::timeout_at(end, async {
+        for _ in 0..20 {
+            let msg = receive_next_message_from(&mut r2, p1.clone()).await;
+            assert_eq!(large_msg, msg);
+        }
+    })
+    .await
+    .unwrap();
+}
+
+async fn receive_next_message_from(
+    r: &mut tx5::EndpointRecv,
+    url: PeerUrl,
+) -> Vec<u8> {
+    loop {
+        let evt = r.recv().await;
+        match evt {
+            Some(tx5::EndpointEvent::Message { peer_url, message }) => {
+                if peer_url != url {
+                    panic!("Received message from unexpected peer: {peer_url}");
+                }
+
+                return message;
+            }
+            Some(evt) => {
+                tracing::info!("Received unexpected event: {evt:?}");
+
+                continue; // Ignore other events
+            }
+            None => panic!("Unexpected end of receiver"),
+        }
+    }
+}

--- a/crates/tx5/tests/tests/stress.rs
+++ b/crates/tx5/tests/tests/stress.rs
@@ -1,3 +1,4 @@
+use crate::tests::enable_tracing;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
@@ -17,14 +18,7 @@ async fn stress_large_msg() {
 }
 
 async fn stress_msg_size(msg_count: usize, size: usize) {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(
-            tracing_subscriber::filter::EnvFilter::from_default_env(),
-        )
-        .with_file(true)
-        .with_line_number(true)
-        .finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    enable_tracing();
 
     let msg = vec![0xdb; size];
 


### PR DESCRIPTION
- Add a new test that can be tuned to make signal demonstrate rate limiting. By enabling, disabling or lowering rate limiting you can see how the runtime of the test is affected
- Add some extra tracing
- Refactored a bunch of nearly-duplicated code for starting an SBD server and creating an endpoint.