### PR TITLE
Backport 0.3 fix connections should close when signal unavailable

### DIFF
--- a/crates/tx5-connection/src/conn.rs
+++ b/crates/tx5-connection/src/conn.rs
@@ -158,7 +158,7 @@ impl Conn {
         let _ = self.ready.acquire().await;
     }
 
-    /// Returns `true` if we sucessfully connected over webrtc.
+    /// Returns `true` if we successfully connected over webrtc.
     pub fn is_using_webrtc(&self) -> bool {
         self.is_webrtc.load(Ordering::SeqCst)
     }

--- a/crates/tx5-connection/src/framed.rs
+++ b/crates/tx5-connection/src/framed.rs
@@ -167,7 +167,7 @@ impl FramedConn {
         &self.pub_key
     }
 
-    /// Returns `true` if we sucessfully connected over webrtc.
+    /// Returns `true` if we successfully connected over webrtc.
     pub fn is_using_webrtc(&self) -> bool {
         if let Some(conn) = self.weak_conn.upgrade() {
             conn.is_using_webrtc()

--- a/crates/tx5-connection/src/hub.rs
+++ b/crates/tx5-connection/src/hub.rs
@@ -52,7 +52,7 @@ async fn hub_map_assert(
 
     client.assert(&pub_key).await?;
 
-    // we're connected to the peer, create a connection
+    // we're not connected to the peer, create a connection
 
     let (conn, recv, cmd_send) = Conn::priv_new(
         webrtc_config.lock().unwrap().clone(),

--- a/crates/tx5/src/backend.rs
+++ b/crates/tx5/src/backend.rs
@@ -116,6 +116,7 @@ pub trait BackWaitCon: 'static + Send {
     /// Wait for the connection
     fn wait(
         &mut self,
+        timeout: std::time::Duration,
         // TODO - this isn't good encapsulation
         recv_limit: Arc<tokio::sync::Semaphore>,
     ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecvData)>>;

--- a/crates/tx5/src/backend/be_tx5_connection.rs
+++ b/crates/tx5/src/backend/be_tx5_connection.rs
@@ -40,6 +40,7 @@ struct GoWaitCon {
 impl BackWaitCon for GoWaitCon {
     fn wait(
         &mut self,
+        timeout: std::time::Duration,
         recv_limit: Arc<tokio::sync::Semaphore>,
     ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecvData)>> {
         let con = self.con.take();
@@ -50,7 +51,17 @@ impl BackWaitCon for GoWaitCon {
                 _ => return Err(std::io::Error::other("already awaited")),
             };
 
-            con.ready().await;
+            // This connection will only ready on a code path that successfully establishes either
+            // a WebRTC or a relayed connection. However, there are many exits from the code paths
+            // that attempt to set those up. In those cases, we own a semaphore permit that will
+            // never be released and we risk deadlocking here without this timeout.
+            tokio::time::timeout(timeout, con.ready())
+                .await
+                .map_err(|e| {
+                    std::io::Error::other(format!(
+                        "timed out waiting for connection to ready: {e}"
+                    ))
+                })?;
 
             let (con, con_recv) =
                 tx5_connection::FramedConn::new(con, con_recv, recv_limit)
@@ -115,7 +126,7 @@ pub fn default_config() -> serde_json::Value {
     serde_json::json!({})
 }
 
-/// Connect a new backend based on the tx5-go-pion backend.
+/// Connect a new backend based on the configured backend module.
 pub async fn connect(
     config: &Arc<Config>,
     url: &str,

--- a/crates/tx5/src/backend/mem.rs
+++ b/crates/tx5/src/backend/mem.rs
@@ -79,6 +79,7 @@ struct WaitCon {
 impl BackWaitCon for WaitCon {
     fn wait(
         &mut self,
+        _timeout: std::time::Duration,
         _recv_limit: Arc<tokio::sync::Semaphore>,
     ) -> BoxFuture<'static, Result<(DynBackCon, DynBackConRecvData)>> {
         let con = self.con.take().unwrap();
@@ -303,7 +304,10 @@ mod tests {
         assert_eq!(w1.pub_key(), e2.pub_key());
 
         let (c1, _cr1) = w1
-            .wait(Arc::new(tokio::sync::Semaphore::new(1)))
+            .wait(
+                std::time::Duration::from_secs(30),
+                Arc::new(tokio::sync::Semaphore::new(1)),
+            )
             .await
             .unwrap();
 
@@ -314,7 +318,10 @@ mod tests {
         assert_eq!(w2.pub_key(), e1.pub_key());
 
         let (c2, mut cr2) = w2
-            .wait(Arc::new(tokio::sync::Semaphore::new(1)))
+            .wait(
+                std::time::Duration::from_secs(30),
+                Arc::new(tokio::sync::Semaphore::new(1)),
+            )
             .await
             .unwrap();
 

--- a/crates/tx5/src/config.rs
+++ b/crates/tx5/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub recv_buffer_bytes_max: u32,
 
     /// Maximum receive message reconstruction bytes in memory
-    /// (accross entire endpoint). Default 512 MiB.
+    /// (across entire endpoint). Default 512 MiB.
     pub incoming_message_bytes_max: u32,
 
     /// Maximum size of an individual message. Default 16 MiB.

--- a/crates/tx5/src/ep.rs
+++ b/crates/tx5/src/ep.rs
@@ -229,6 +229,7 @@ impl Endpoint {
     }
 
     /// Send data to a remote on this tx5 endpoint.
+    ///
     /// The future returned from this method will resolve when
     /// the data is handed off to our networking backend.
     pub async fn send(&self, peer_url: PeerUrl, data: Vec<u8>) -> Result<()> {
@@ -241,6 +242,7 @@ impl Endpoint {
     }
 
     /// Broadcast data to all connections that happen to be open.
+    ///
     /// If no connections are open, no data will be broadcast.
     /// The future returned from this method will resolve when all
     /// broadcast messages have been handed off to our networking backend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * WebRTC configuration is now handled as raw JSON bytes instead of structured types, simplifying configuration management.
  * The method for waiting on connections now supports a timeout, improving reliability and preventing potential deadlocks.
  * Various internal types and features related to schema generation and structured WebRTC config have been removed.

* **Style / Documentation**
  * Improved documentation comments and fixed typos for clarity.
  * Clarified comments regarding connection lifecycle and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->