### PR TITLE
fix: more places where the receiver task might block and leave an unusable connection in the endpoint's state

### DIFF
--- a/crates/tx5/src/peer.rs
+++ b/crates/tx5/src/peer.rs
@@ -285,7 +285,8 @@ async fn task(
                 return;
             }
             Err(err) => {
-                tracing::info!(?err, ?peer_url, "preflight timed out")
+                tracing::info!(?err, ?peer_url, "preflight timed out");
+                return;
             }
         }
     }


### PR DESCRIPTION
Backport #171