### PR TITLE
perf: Drop outbound messages when the connection closes, without waiting for a timeout

### DIFF
--- a/crates/tx5/src/peer.rs
+++ b/crates/tx5/src/peer.rs
@@ -1,16 +1,14 @@
 use crate::*;
 
+use crate::peer::maybe_ready::MaybeReady;
 use tx5_connection::*;
 
-enum MaybeReady {
-    Ready(Arc<DynBackCon>),
-    Wait(Arc<tokio::sync::Semaphore>),
-}
+mod maybe_ready;
 
 /// This struct represents a connection to an individual peer.
 /// It is a pretty thin wrapper around the tx5-connection "Conn".
 pub(crate) struct Peer {
-    ready: Arc<Mutex<MaybeReady>>,
+    ready: MaybeReady,
     task: tokio::task::JoinHandle<()>,
     pub(crate) pub_key: PubKey,
     pub(crate) opened_at_s: u64,
@@ -39,8 +37,7 @@ impl Peer {
         evt_send: tokio::sync::mpsc::Sender<EndpointEvent>,
     ) -> Arc<Self> {
         Arc::new_cyclic(|_this| {
-            let wait = Arc::new(tokio::sync::Semaphore::new(0));
-            let ready = Arc::new(Mutex::new(MaybeReady::Wait(wait)));
+            let ready = MaybeReady::new();
             let pub_key = peer_url.pub_key().clone();
 
             let task = tokio::task::spawn(connect(
@@ -75,8 +72,7 @@ impl Peer {
         evt_send: tokio::sync::mpsc::Sender<EndpointEvent>,
     ) -> Arc<Self> {
         Arc::new_cyclic(|_this| {
-            let wait = Arc::new(tokio::sync::Semaphore::new(0));
-            let ready = Arc::new(Mutex::new(MaybeReady::Wait(wait)));
+            let ready = MaybeReady::new();
             let pub_key = peer_url.pub_key().clone();
 
             let task = tokio::task::spawn(task(
@@ -101,41 +97,26 @@ impl Peer {
     }
 
     /// This is initially false, but can transition into true.
+    ///
     /// If establishing a webrtc connection fails, it will remain false.
     pub fn is_using_webrtc(&self) -> bool {
-        if let MaybeReady::Ready(r) = &*self.ready.lock().unwrap() {
-            r.is_using_webrtc()
-        } else {
-            false
-        }
+        self.ready
+            .query_ready(|c| c.is_using_webrtc())
+            .unwrap_or_default()
     }
 
     /// Get connection statistics.
     pub fn get_stats(&self) -> ConnStats {
-        if let MaybeReady::Ready(r) = &*self.ready.lock().unwrap() {
-            r.get_stats()
-        } else {
-            ConnStats::default()
-        }
+        self.ready
+            .query_ready(|c| c.get_stats())
+            .unwrap_or_default()
     }
 
-    /// This future resolves when the connection is ready to use.
-    pub async fn ready(&self) {
-        let w = match &*self.ready.lock().unwrap() {
-            MaybeReady::Ready(_) => return,
-            MaybeReady::Wait(w) => w.clone(),
-        };
-
-        let _ = w.acquire().await;
-    }
-
-    /// Send data to the remote peer over this connection.
-    pub async fn send(&self, msg: Vec<u8>) -> Result<()> {
-        let conn = match &*self.ready.lock().unwrap() {
-            MaybeReady::Ready(c) => c.clone(),
-            _ => return Err(Error::other("not ready")),
-        };
-        conn.send(msg).await
+    /// This future resolves when the connection is ready to use or has failed to connect.
+    ///
+    /// If the connection is not usable, it will return `None`.
+    pub async fn wait_for_ready(&self) -> Option<DynBackCon> {
+        self.ready.wait_for_ready().await
     }
 }
 
@@ -147,7 +128,7 @@ async fn connect(
     ep: Weak<Mutex<EpInner>>,
     peer_url: PeerUrl,
     evt_send: tokio::sync::mpsc::Sender<EndpointEvent>,
-    ready: Arc<Mutex<MaybeReady>>,
+    ready: MaybeReady,
 ) {
     tracing::trace!(?peer_url, "peer try connect");
 
@@ -187,6 +168,7 @@ struct DropPeer {
     ep: Weak<Mutex<EpInner>>,
     peer_url: PeerUrl,
     evt_send: tokio::sync::mpsc::Sender<EndpointEvent>,
+    ready: MaybeReady,
 }
 
 impl Drop for DropPeer {
@@ -196,6 +178,9 @@ impl Drop for DropPeer {
         if let Some(ep_inner) = self.ep.upgrade() {
             ep_inner.lock().unwrap().drop_peer_url(&self.peer_url);
         }
+
+        // Mark the connection as failed so that the `ready` future resolves for all waiters.
+        self.ready.set_failed();
 
         let evt_send = self.evt_send.clone();
         let peer_url = self.peer_url.clone();
@@ -226,13 +211,14 @@ async fn task(
     conn: Option<DynBackWaitCon>,
     peer_url: PeerUrl,
     evt_send: tokio::sync::mpsc::Sender<EndpointEvent>,
-    ready: Arc<Mutex<MaybeReady>>,
+    ready: MaybeReady,
 ) {
     // establish our cleanup drop guard
     let _drop = DropPeer {
         ep,
         peer_url: peer_url.clone(),
         evt_send: evt_send.clone(),
+        ready: ready.clone(),
     };
 
     let mut wc = match conn {
@@ -305,13 +291,7 @@ async fn task(
     }
 
     // store a handle for use sending outgoing data
-    {
-        let mut lock = ready.lock().unwrap();
-        if let MaybeReady::Wait(w) = &*lock {
-            w.close();
-        }
-        *lock = MaybeReady::Ready(Arc::new(conn));
-    }
+    ready.set_ready(conn);
 
     // send the notification that the connection is ready
     drop(ready);

--- a/crates/tx5/src/peer/maybe_ready.rs
+++ b/crates/tx5/src/peer/maybe_ready.rs
@@ -1,0 +1,207 @@
+use crate::backend::DynBackCon;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub(super) struct MaybeReady(Arc<Mutex<MaybeReadyState>>);
+
+enum MaybeReadyState {
+    Ready(DynBackCon),
+    Failed,
+    Wait(Arc<tokio::sync::Semaphore>),
+}
+
+impl MaybeReady {
+    pub(super) fn new() -> Self {
+        MaybeReady(Arc::new(Mutex::new(MaybeReadyState::Wait(Arc::new(
+            tokio::sync::Semaphore::new(0),
+        )))))
+    }
+
+    pub(super) fn query_ready<T>(
+        &self,
+        query: fn(&DynBackCon) -> T,
+    ) -> Option<T> {
+        let lock = self.0.lock().expect("poisoned");
+        match &*lock {
+            MaybeReadyState::Ready(c) => Some(query(c)),
+            _ => None,
+        }
+    }
+
+    pub(super) fn set_ready(&self, conn: DynBackCon) {
+        let mut lock = self.0.lock().expect("poisoned");
+        match &*lock {
+            MaybeReadyState::Wait(w) => {
+                // Close the wait semaphore to unblock waiters.
+                w.close();
+            }
+            MaybeReadyState::Failed => {
+                tracing::error!(
+                    "Cannot set state to ready because state is already failed"
+                );
+                return;
+            }
+            MaybeReadyState::Ready(_) => {
+                tracing::error!(
+                    "Cannot set state to ready because state is already ready"
+                );
+                return;
+            }
+        }
+
+        *lock = MaybeReadyState::Ready(conn);
+    }
+
+    pub(super) fn set_failed(&self) {
+        let mut lock = self.0.lock().expect("poisoned");
+        match &*lock {
+            MaybeReadyState::Wait(w) => {
+                // Close the wait semaphore to unblock waiters.
+                w.close();
+            }
+            MaybeReadyState::Failed => {
+                // Don't warn about duplicate failed calls, it's a no-op and not doing any harm.
+                return;
+            }
+            MaybeReadyState::Ready(_) => {
+                // Have to quietly permit this too because it's used in a drop implementation which
+                // can happen either before or after the connection was marked ready.
+                return;
+            }
+        }
+
+        *lock = MaybeReadyState::Failed;
+    }
+
+    pub(super) async fn wait_for_ready(&self) -> Option<DynBackCon> {
+        let wait = {
+            let lock = self.0.lock().expect("poisoned");
+            match &*lock {
+                MaybeReadyState::Ready(back) => return Some(back.clone()),
+                MaybeReadyState::Failed => return None,
+                MaybeReadyState::Wait(wait) => wait.clone(),
+            }
+        };
+
+        let _ = wait.acquire().await;
+
+        let lock = self.0.lock().expect("poisoned");
+        match &*lock {
+            MaybeReadyState::Ready(back) => Some(back.clone()),
+            MaybeReadyState::Failed => None,
+            MaybeReadyState::Wait(_) => {
+                // Unexpected state, this struct is supposed to prevent this being possible.
+                tracing::warn!("Waited for ready but still in a wait state");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::BackCon;
+    use crate::PubKey;
+    use futures::future::BoxFuture;
+    use tx5_connection::ConnStats;
+
+    struct NoopCon {
+        pub_key: PubKey,
+    }
+
+    impl BackCon for NoopCon {
+        fn send(&self, _data: Vec<u8>) -> BoxFuture<'_, std::io::Result<()>> {
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn pub_key(&self) -> &PubKey {
+            &self.pub_key
+        }
+
+        fn is_using_webrtc(&self) -> bool {
+            false
+        }
+
+        fn get_stats(&self) -> ConnStats {
+            ConnStats::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn ready() {
+        let maybe_ready = MaybeReady::new();
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        tokio::spawn({
+            let maybe_ready = maybe_ready.clone();
+            async move {
+                tx.send(maybe_ready.wait_for_ready().await.is_some())
+                    .unwrap();
+            }
+        });
+
+        // Not ready, should fail to receive.
+        tokio::time::timeout(std::time::Duration::from_millis(10), &mut rx)
+            .await
+            .unwrap_err();
+
+        assert!(
+            maybe_ready.query_ready(|c| c.pub_key().clone()).is_none(),
+            "Not ready, shouldn't be able to query"
+        );
+
+        maybe_ready.set_ready(Arc::new(NoopCon {
+            pub_key: PubKey(Arc::new([0; 32])),
+        }));
+
+        // Now is ready, should receive boolean true.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            "Expected a successful ready"
+        );
+
+        assert!(
+            maybe_ready.query_ready(|c| c.pub_key().clone()).is_some(),
+            "Is ready, should be able to query"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed() {
+        let maybe_ready = MaybeReady::new();
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        tokio::spawn({
+            let maybe_ready = maybe_ready.clone();
+            async move {
+                tx.send(maybe_ready.wait_for_ready().await.is_none())
+                    .unwrap();
+            }
+        });
+
+        // Not failed, should fail to receive.
+        tokio::time::timeout(std::time::Duration::from_millis(10), &mut rx)
+            .await
+            .unwrap_err();
+
+        maybe_ready.set_failed();
+
+        // Now is failed, should receive boolean true.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            "Expected a failed state"
+        );
+
+        assert!(
+            maybe_ready.query_ready(|c| c.pub_key().clone()).is_none(),
+            "Is failed, shouldn't be able to query"
+        );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of peer connections and message delivery.
  * Sends now return a clear error when a connection can’t be established.
  * Broadcast skips unreachable peers without blocking other sends.
  * Reduced risk of stalls during connection setup; dropped messages are logged for diagnostics.

* **Refactor**
  * Streamlined connection readiness handling for lower overhead and faster responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->