### PR TITLE
fix: Avoid downloading Go toolchain on build

### DIFF
--- a/crates/tx5-go-pion-sys/build.rs
+++ b/crates/tx5-go-pion-sys/build.rs
@@ -109,6 +109,7 @@ fn go_check_version() {
 
     let go_version = Command::new("go")
         .arg("version")
+        .env("GOTOOLCHAIN", "local")
         .output()
         .expect("error checking go version");
 
@@ -127,8 +128,8 @@ fn go_check_version() {
     // Only check the go version if this is NOT a DOCS_RS build.
     if std::env::var("DOCS_RS").is_err() {
         assert!(
-            ver >= 1.20,
-            "go executable version must be >= 1.20, got: {ver}",
+            ver >= 1.24,
+            "go executable version must be >= 1.24, got: {ver}",
         );
     }
 }
@@ -164,8 +165,8 @@ fn go_build_cmd(
 
     let mut cmd = Command::new("go");
 
+    cmd.env("GOTOOLCHAIN", "local");
     cmd.env("GOARCH", TARGET.go_arch);
-
     cmd.env("GOOS", TARGET.go_os);
 
     if let Ok(linker) = std::env::var("RUSTC_LINKER") {

--- a/crates/tx5-go-pion-turn/build.rs
+++ b/crates/tx5-go-pion-turn/build.rs
@@ -19,6 +19,7 @@ fn main() {
 fn go_check_version() {
     let go_version = Command::new("go")
         .arg("version")
+        .env("GOTOOLCHAIN", "local")
         .output()
         .expect("error checking go version");
     assert_eq!(b"go version go", &go_version.stdout[0..13]);
@@ -26,8 +27,8 @@ fn go_check_version() {
         .parse()
         .expect("error parsing go version");
     assert!(
-        ver >= 1.18,
-        "go executable version must be >= 1.18, got: {ver}",
+        ver >= 1.24,
+        "go executable version must be >= 1.24, got: {ver}",
     );
 }
 
@@ -75,6 +76,8 @@ fn go_build(path: &std::path::Path) {
     cp("go.mod");
 
     let mut cmd = Command::new("go");
+
+    cmd.env("GOTOOLCHAIN", "local");
 
     // add some cross-compilation translators:
     match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {


### PR DESCRIPTION
This is clearly a bad idea. It causes problems in Nix, it's broken the release automation release. 

This didn't used to happen on older Go versions, it was introduced at Go 1.21 apparently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased minimum Go version requirement to 1.24 for building Go-based components.
  * Build steps now enforce the local Go toolchain for version checks and compilation.
  * Developers may need to upgrade Go to continue building from source.
  * No changes to runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->