### PR TITLE
fix: incompatible WebRtcConfig for go-pion

### DIFF
--- a/crates/tx5-connection/src/config.rs
+++ b/crates/tx5-connection/src/config.rs
@@ -57,21 +57,22 @@ pub struct IceServers {
     pub urls: Vec<String>,
 
     /// The username to use for authentication.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
 
     /// The credential to use for authentication.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential: Option<String>,
 
     /// The credential type to use for authentication.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_type: Option<CredentialType>,
 }
 
 /// ICE transport policy.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub enum TransportPolicy {
     /// Any type of candidate can be used.
     #[default]


### PR DESCRIPTION

It wasn't actually possible to configure the go-pion backend to make p2p connections except on a local network. This is only affecting 0.6 currently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Serialized configuration now omits empty ICE server credential fields, producing cleaner outputs.
  * Transport policy values in serialized configuration now use camelCase for improved consistency.

* **Potential Impact**
  * Tools or scripts that relied on always-present (but empty) credential fields or on previous casing for policy values may require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->