### PR TITLE
fix: Time out the WebRTC connection before timing out the connection attempt

### DIFF
--- a/crates/tx5-connection/src/config.rs
+++ b/crates/tx5-connection/src/config.rs
@@ -32,6 +32,14 @@ pub struct HubConfig {
     /// The signal config to use.
     pub signal_config: Arc<tx5_signal::SignalConfig>,
 
+    /// The timeout for establishing a WebRTC connection to a peer.
+    ///
+    /// After this time has elapsed, if a WebRTC connection has not been established, the connection
+    /// will fall back to using the signal server as a relay. Any timeout applied to the
+    /// [`Conn::ready`] or [`Conn::send`] futures should allow enough time for this timeout to
+    /// elapse and for the message to be sent over the relay.
+    pub webrtc_connect_timeout: std::time::Duration,
+
     /// Test falling back to the signal relay by failing the WebRTC setup.
     pub danger_force_signal_relay: bool,
 

--- a/crates/tx5-connection/src/conn.rs
+++ b/crates/tx5-connection/src/conn.rs
@@ -394,7 +394,7 @@ async fn con_task_attempt_webrtc(
 ) -> AttemptWebrtcResult {
     use AttemptWebrtcResult::*;
 
-    let timeout_dur = task_core.config.signal_config.max_idle;
+    let timeout_dur = task_core.config.webrtc_connect_timeout;
     let timeout_cmd_send = task_core.cmd_send.clone();
     tokio::task::spawn(async move {
         tokio::time::sleep(timeout_dur).await;

--- a/crates/tx5-connection/src/test.rs
+++ b/crates/tx5-connection/src/test.rs
@@ -65,6 +65,7 @@ impl TestSrv {
                         max_idle: std::time::Duration::from_secs(max_idle_secs),
                         ..Default::default()
                     }),
+                    webrtc_connect_timeout: std::time::Duration::from_secs(15),
                     danger_force_signal_relay: self.danger_force_signal_relay,
                     danger_deny_signal_relay: self.danger_deny_signal_relay,
                 }),

--- a/crates/tx5-demo/src/main.rs
+++ b/crates/tx5-demo/src/main.rs
@@ -331,10 +331,9 @@ async fn main_err() -> Result<()> {
 
     let sig_url = tx5::SigUrl::parse(sig_url)?;
 
-    let (ep, mut evt) = tx5::Endpoint::new(Arc::new(Config {
-        signal_allow_plain_text: true,
-        ..Default::default()
-    }));
+    let (ep, mut evt) = tx5::Endpoint::new(Arc::new(
+        Config::new().with_signal_allow_plain_text(true),
+    ));
     let ep = Arc::new(ep);
 
     d!(info, "LISTEN", "{sig_url}");

--- a/crates/tx5/benches/throughput.rs
+++ b/crates/tx5/benches/throughput.rs
@@ -34,10 +34,7 @@ impl Test {
         ))
         .unwrap();
 
-        let config = Arc::new(Config {
-            signal_allow_plain_text: true,
-            ..Default::default()
-        });
+        let config = Arc::new(Config::new().with_signal_allow_plain_text(true));
 
         let (ep1, mut ep_rcv1) = Endpoint::new(config.clone());
         ep1.listen(sig_url.clone()).await;

--- a/crates/tx5/examples/mem-echo-stress.rs
+++ b/crates/tx5/examples/mem-echo-stress.rs
@@ -14,10 +14,8 @@ use tx5::{backend::*, *};
 async fn main() {
     let fake_sig = SigUrl::parse("wss://fake.fake").unwrap();
 
-    let config = Arc::new(Config {
-        backend_module: BackendModule::Mem,
-        ..Default::default()
-    });
+    let config =
+        Arc::new(Config::new().with_backend_module(BackendModule::Mem));
 
     let (listen_ep, mut listen_recv) = Endpoint::new(config.clone());
     let listen_ep = Arc::new(listen_ep);

--- a/crates/tx5/src/config.rs
+++ b/crates/tx5/src/config.rs
@@ -3,54 +3,99 @@ use tx5_connection::WebRtcConfig;
 use tx5_core::deps::serde_json;
 
 /// Tx5 endpoint configuration.
+#[derive(Clone)]
+#[non_exhaustive]
 pub struct Config {
     /// Allow plain text (non-tls) signal server connections.
+    ///
+    /// Default: false (require TLS).
     pub signal_allow_plain_text: bool,
 
     /// Supply signal authentication material.
+    ///
+    /// Default: None (no authentication).
     pub signal_auth_material: Option<Vec<u8>>,
 
     /// Initial webrtc peer connection config.
     pub initial_webrtc_config: WebRtcConfig,
 
-    /// Maximum count of open connections. Default 4096.
+    /// Maximum count of open connections.
+    ///
+    /// Default 4096.
     pub connection_count_max: u32,
 
-    /// Max backend send buffer bytes (per connection). Default 64 KiB.
+    /// Max backend send buffer bytes (per connection).
+    ///
+    /// Default: 64 KiB.
     pub send_buffer_bytes_max: u32,
 
-    /// Max backend recv buffer bytes (per connection). Default 64 KiB.
+    /// Max backend recv buffer bytes (per connection).
+    ///
+    /// Default: 64 KiB.
     pub recv_buffer_bytes_max: u32,
 
     /// Maximum receive message reconstruction bytes in memory
-    /// (across entire endpoint). Default 512 MiB.
+    /// (across entire endpoint).
+    ///
+    /// Default: 512 MiB.
     pub incoming_message_bytes_max: u32,
 
-    /// Maximum size of an individual message. Default 16 MiB.
+    /// Maximum size of an individual message.
+    ///
+    /// Default: 16 MiB.
     pub message_size_max: u32,
 
-    /// Internal event channel size. Default is 1024.
+    /// Internal event channel size.
+    ///
+    /// Default: 1024.
     pub internal_event_channel_size: u32,
 
-    /// Default timeout for network operations. Default 60 seconds.
+    /// Default timeout for network operations.
+    ///
+    /// Default: 60 seconds.
     pub timeout: std::time::Duration,
 
-    /// Starting backoff duration for retries. Default 5 seconds.
+    /// The timeout for establishing a WebRTC connection to a peer.
+    ///
+    /// This value *must* be less than [`Config::timeout`], otherwise the connection attempt will
+    /// be treated as failed without attempting to fall back to the signal relay.
+    ///
+    /// A lower value for this timeout will make tx5 fall back to the signal relay faster. That
+    /// makes tx5 more responsive when direct connections are not possible. It also increases
+    /// the chance that connections end up being relayed unnecessarily when a direct connection
+    /// could have been established with a bit more time.
+    ///
+    /// The default of 45 seconds is a trade-off that gives WebRTC plenty of time to establish a
+    /// direct connection in most situations while still leaving some time for the signal relay to
+    /// be used within the overall timeout.
+    ///
+    /// Default: 45 seconds.
+    pub webrtc_connect_timeout: std::time::Duration,
+
+    /// Starting backoff duration for retries.
+    ///
+    /// Default: 5 seconds.
     pub backoff_start: std::time::Duration,
 
-    /// Max backoff duration for retries. Default 60 seconds.
+    /// Max backoff duration for retries.
+    ///
+    /// Default: 60 seconds.
     pub backoff_max: std::time::Duration,
 
     /// If the protocol should manage a preflight message,
     /// set the callbacks here, otherwise no preflight will
-    /// be sent nor validated. Default: None.
+    /// be sent nor validated.
+    ///
+    /// Default: None.
     pub preflight: Option<(PreflightSendCb, PreflightCheckCb)>,
 
     /// The backend connection module to use.
+    ///
     /// For the most part you should just leave this at the default.
     pub backend_module: crate::backend::BackendModule,
 
     /// The backend module config to use.
+    ///
     /// For the most part you should just leave this set at `None`,
     /// to get the default backend config.
     pub backend_module_config: Option<serde_json::Value>,
@@ -101,6 +146,13 @@ impl std::fmt::Debug for Config {
 
 impl Default for Config {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Config {
+    /// Create a new default config.
+    pub fn new() -> Config {
         Self {
             signal_allow_plain_text: false,
             signal_auth_material: None,
@@ -112,6 +164,7 @@ impl Default for Config {
             message_size_max: 16 * 1024 * 1024,
             internal_event_channel_size: 1024,
             timeout: std::time::Duration::from_secs(60),
+            webrtc_connect_timeout: std::time::Duration::from_secs(45),
             backoff_start: std::time::Duration::from_secs(5),
             backoff_max: std::time::Duration::from_secs(60),
             preflight: None,
@@ -120,5 +173,63 @@ impl Default for Config {
             danger_force_signal_relay: false,
             danger_deny_signal_relay: false,
         }
+    }
+
+    /// Set whether to allow plain text (non-tls) signal server connections.
+    pub fn with_signal_allow_plain_text(mut self, allow: bool) -> Self {
+        self.signal_allow_plain_text = allow;
+        self
+    }
+
+    /// Set the signal authentication material.
+    pub fn with_signal_auth_material(mut self, auth: Vec<u8>) -> Self {
+        self.signal_auth_material = Some(auth);
+        self
+    }
+
+    /// Set the initial webrtc peer connection config.
+    pub fn with_initial_webrtc_config(mut self, config: WebRtcConfig) -> Self {
+        self.initial_webrtc_config = config;
+        self
+    }
+
+    /// Set the default timeout for network operations.
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Set the timeout for establishing a WebRTC connection to a peer.
+    pub fn with_webrtc_connect_timeout(
+        mut self,
+        timeout: std::time::Duration,
+    ) -> Self {
+        self.webrtc_connect_timeout = timeout;
+        self
+    }
+
+    /// Set the preflight callbacks.
+    pub fn with_preflight(
+        mut self,
+        send_cb: PreflightSendCb,
+        check_cb: PreflightCheckCb,
+    ) -> Self {
+        self.preflight = Some((send_cb, check_cb));
+        self
+    }
+
+    /// Set the backend connection module to use.
+    pub fn with_backend_module(mut self, module: BackendModule) -> Self {
+        self.backend_module = module;
+        self
+    }
+
+    /// Set the backend module config to use.
+    pub fn with_backend_module_config(
+        mut self,
+        config: serde_json::Value,
+    ) -> Self {
+        self.backend_module_config = Some(config);
+        self
     }
 }

--- a/crates/tx5/tests/tests/events.rs
+++ b/crates/tx5/tests/tests/events.rs
@@ -37,22 +37,12 @@ async fn connected_event_is_consistent() {
 #[tokio::test(flavor = "multi_thread")]
 async fn connected_event_is_consistent_fail_webrtc() {
     let sig = sbd().await;
-    let (_p1, e1, mut r1) = ep_with_config(
-        &sig,
-        tx5::Config {
-            danger_force_signal_relay: true,
-            ..Default::default()
-        },
-    )
-    .await;
-    let (p2, e2, mut r2) = ep_with_config(
-        &sig,
-        tx5::Config {
-            danger_force_signal_relay: true,
-            ..Default::default()
-        },
-    )
-    .await;
+
+    let mut config = tx5::Config::new();
+    config.danger_force_signal_relay = true;
+
+    let (_p1, e1, mut r1) = ep_with_config(&sig, config.clone()).await;
+    let (p2, e2, mut r2) = ep_with_config(&sig, config).await;
 
     e1.send(p2.clone(), b"hello".to_vec()).await.unwrap();
 
@@ -143,22 +133,12 @@ async fn disconnected_event_is_consistent() {
 #[ignore = "TODO - this test doesn't pass (https://github.com/holochain/tx5/issues/130)"]
 async fn disconnected_event_is_consistent_fail_webrtc() {
     let sig = sbd().await;
-    let (_p1, e1, mut r1) = ep_with_config(
-        &sig,
-        tx5::Config {
-            danger_force_signal_relay: true,
-            ..Default::default()
-        },
-    )
-    .await;
-    let (p2, _e2, mut r2) = ep_with_config(
-        &sig,
-        tx5::Config {
-            danger_force_signal_relay: true,
-            ..Default::default()
-        },
-    )
-    .await;
+
+    let mut config = tx5::Config::new();
+    config.danger_force_signal_relay = true;
+
+    let (_p1, e1, mut r1) = ep_with_config(&sig, config.clone()).await;
+    let (p2, _e2, mut r2) = ep_with_config(&sig, config).await;
 
     e1.send(p2.clone(), b"hello".to_vec()).await.unwrap();
 

--- a/crates/tx5/tests/tests/flaky_sig.rs
+++ b/crates/tx5/tests/tests/flaky_sig.rs
@@ -203,11 +203,9 @@ impl FlakyRelay {
 async fn ep_for_relay(
     bound_addr: std::net::SocketAddr,
 ) -> (PeerUrl, Endpoint, EndpointRecv) {
-    let config = tx5::Config {
-        signal_allow_plain_text: true,
-        timeout: std::time::Duration::from_secs(5),
-        ..Default::default()
-    };
+    let config = tx5::Config::new()
+        .with_signal_allow_plain_text(true)
+        .with_timeout(std::time::Duration::from_secs(5));
 
     let (ep, recv) = Endpoint::new(Arc::new(config));
     let sig = format!("ws://{}", bound_addr);

--- a/crates/tx5/tests/tests/mod.rs
+++ b/crates/tx5/tests/tests/mod.rs
@@ -27,10 +27,9 @@ async fn sbd_with_config(
 }
 
 async fn ep(s: &sbd_server::SbdServer) -> (PeerUrl, Endpoint, EndpointRecv) {
-    let config = tx5::Config {
-        signal_allow_plain_text: true, // Always allow plain text for tests
-        ..Default::default()
-    };
+    let config = tx5::Config::new()
+        // Always allow plain text for tests
+        .with_signal_allow_plain_text(true);
 
     ep_with_config(s, config).await
 }

--- a/crates/tx5/tests/tests/reconnect.rs
+++ b/crates/tx5/tests/tests/reconnect.rs
@@ -69,33 +69,19 @@ async fn close_connections_on_setup_failure() {
 
     let sig = sbd().await;
 
-    let (p1, e1, _r1) = ep_with_config(
-        &sig,
-        tx5::Config {
-            // By enabling both of these, the connection setup is forced to fail because we aren't
-            // allowing it to use either of its options.
-            // In production this is a misconfiguration, but it is a useful situation for testing that
-            // the resources that get allocated on the way to discovering the misconfiguration are
-            // cleaned up.
-            danger_force_signal_relay: true,
-            danger_deny_signal_relay: true,
-            // Want to give up quickly on the connection setup, so we don't wait too long.
-            timeout: std::time::Duration::from_secs(3),
-            ..Default::default()
-        },
-    )
-    .await;
+    let mut config = tx5::Config::new();
+    // By enabling both of these, the connection setup is forced to fail because we aren't
+    // allowing it to use either of its options.
+    // In production this is a misconfiguration, but it is a useful situation for testing that
+    // the resources that get allocated on the way to discovering the misconfiguration are
+    // cleaned up.
+    config.danger_deny_signal_relay = true;
+    config.danger_force_signal_relay = true;
+    config.timeout = std::time::Duration::from_secs(3);
 
-    let (p2, e2, _r2) = ep_with_config(
-        &sig,
-        tx5::Config {
-            danger_force_signal_relay: true,
-            danger_deny_signal_relay: true,
-            timeout: std::time::Duration::from_secs(3),
-            ..Default::default()
-        },
-    )
-    .await;
+    let (p1, e1, _r1) = ep_with_config(&sig, config.clone()).await;
+
+    let (p2, e2, _r2) = ep_with_config(&sig, config).await;
 
     // Each endpoint attempts to send a message to the other.
     //

--- a/crates/tx5/tests/tests/stress.rs
+++ b/crates/tx5/tests/tests/stress.rs
@@ -138,10 +138,7 @@ impl Test {
     }
 
     pub async fn ep(&self) -> TestEp {
-        let config = Arc::new(Config {
-            signal_allow_plain_text: true,
-            ..Default::default()
-        });
+        let config = Arc::new(Config::new().with_signal_allow_plain_text(true));
         let (ep, ep_recv) = Endpoint::new(config);
         let peer_url = ep.listen(self.sig_url.clone()).await.unwrap();
 


### PR DESCRIPTION
Tx5 sets up several timeouts on the connection path:
- The message send https://github.com/holochain/tx5/blob/main/crates/tx5/src/ep.rs#L246
- The connection attempt https://github.com/holochain/tx5/blob/main/crates/tx5/src/peer.rs#L230
- The WebRTC connection attempt https://github.com/holochain/tx5/blob/e041113abe323d8bc3f19af758f8f2cf91b98540/crates/tx5-connection/src/conn.rs#L400

The first two being the same, means that the message send gives up before the connection attempt gives up. This is only by a small amount in most cases and isn't especially serious i think.

The second pair is really bad. The connection attempt will always timeout before it gives up on connecting WebRTC. As a consequence, we can never use the relay. 

This bug already existed but I've effectively revealed it with the other fixes.

The change can't be backported like this, I'll backport a simpler version of the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable WebRTC connection timeout (default 45s) and builder setter.
  - Options to force or deny signal relay.
  - Config is cloneable with a builder-style API and convenience setters.

- **Refactor**
  - Examples, benchmarks, and tests migrated to the new builder-based configuration.

- **Tests**
  - Relay test renamed and new fallback-after-WebRTC-timeout scenario added.
  - Reconnect and fail-WeRTC tests updated for stricter cleanup and behavior verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->