### PR TITLE
build(android): Android build for libdatachannel

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Go Toolchain
         uses: actions/setup-go@v5
         with:
-          go-version: '=1.24.6'
+          go-version: "=1.24.6"
 
       - name: Rust Toolchain
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,7 @@ jobs:
         android-arch: ["x86_64"]
         android-api-level: [29, 33]
         android-ndk-version: ["26.0.10792818"]
+        backend: [go-pion, datachannel]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,6 +75,7 @@ jobs:
           ANDROID_API_LEVEL: ${{ matrix.android-api-level }}
           ANDROID_NDK_VERSION: ${{ matrix.android-ndk-version }}
           ANDROID_ARCH: ${{ matrix.android-arch }}
+          TX5_BACKEND: ${{ matrix.backend }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -21,11 +21,30 @@ else
   fi
 fi
 
-
 if [[ "${ANDROID_SDK_ROOT:-x}" == "x" ]]; then
   echo "ANDROID_SDK_ROOT required"
   exit 127
 fi
+
+if [[ "${TX5_BACKEND:-x}" == "x" ]]; then
+  echo "TX5_BACKEND required. Supported values are: go-pion, datachannel"
+  exit 127
+fi
+
+# Get rust features for tx5 backend
+TX5_BACKEND_FEATURES=""
+case "$TX5_BACKEND" in
+  "go-pion")
+    TX5_BACKEND_FEATURES="backend-go-pion"
+    ;;
+  "datachannel")
+    TX5_BACKEND_FEATURES="backend-libdatachannel,datachannel-vendored"
+    ;;
+  *)
+    echo "Unsupported TX5_BACKEND: $TX5_BACKEND. Supported values are: go-pion, datachannel"
+    exit 1
+    ;;
+esac
 
 export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
 
@@ -78,7 +97,7 @@ export CFLAGS_x86_64_linux_android="${BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_andr
 
 cargo test -p tx5 \
   --no-default-features \
-  --features backend-go-pion \
+  --features ${TX5_BACKEND_FEATURES} \
   --no-run \
   --target ${ANDROID_ARCH}-linux-android \
   --config target.${ANDROID_ARCH}-linux-android.linker="\"${NDK_ROOT}/bin/${ANDROID_ARCH}-linux-android34-clang\"" \

--- a/android-build-tests.bash
+++ b/android-build-tests.bash
@@ -30,21 +30,26 @@ fi
 export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
 
 ndk_root_folder=""
+case "$(uname -m)" in
+  x86_64) ndk_root_folder="linux-x86_64" ;;
+  aarch64) ndk_root_folder="linux-aarch64" ;;
+  *)
+    echo "Unsupported build host arch: $(uname -m)"
+    exit 1
+    ;;
+esac
+
 case "$ANDROID_ARCH" in
   "arm64-v8a")
-    ndk_root_folder="linux-aarch64"
     export ANDROID_ARCH="aarch64"
     ;;
   "armeabi-v7a")
-    ndk_root_folder="linux-arm"
     export ANDROID_ARCH="arm"
     ;;
   "x86")
-    ndk_root_folder="linux-x86"
     export ANDROID_ARCH="i686"
     ;;
   "x86_64")
-    ndk_root_folder="linux-x86_64"
     export ANDROID_ARCH="x86_64"
     ;;
   *)

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -2,6 +2,67 @@
 
 set -eEuxo pipefail
 
+if [[ "${ANDROID_API_LEVEL:-x}" == "x" ]]; then
+  echo "ANDROID_API_LEVEL required"
+  exit 127
+fi
+
+if [[ "${ANDROID_NDK_VERSION:-x}" == "x" ]]; then
+  echo "ANDROID_NDK_VERSION required"
+  exit 127
+fi
+
+if [[ "${ANDROID_ARCH:-x}" == "x" ]]; then
+  echo "ANDROID_ARCH required"
+  exit 127
+else
+  if [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]; then
+    export ANDROID_ARCH="aarch64"
+  fi
+fi
+
+
+if [[ "${ANDROID_SDK_ROOT:-x}" == "x" ]]; then
+  echo "ANDROID_SDK_ROOT required"
+  exit 127
+fi
+
+export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
+
+ndk_root_folder=""
+case "$ANDROID_ARCH" in
+  "arm64-v8a")
+    ndk_root_folder="linux-aarch64"
+    export ANDROID_ARCH="aarch64"
+    ;;
+  "armeabi-v7a")
+    ndk_root_folder="linux-arm"
+    export ANDROID_ARCH="arm"
+    ;;
+  "x86")
+    ndk_root_folder="linux-x86"
+    export ANDROID_ARCH="i686"
+    ;;
+  "x86_64")
+    ndk_root_folder="linux-x86_64"
+    export ANDROID_ARCH="x86_64"
+    ;;
+  *)
+    echo "Unsupported ANDROID_ARCH: $ANDROID_ARCH"
+    exit 1
+    ;;
+esac
+
+NDK_ROOT="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/${ndk_root_folder}"
+if [ ! -d "$NDK_ROOT" ]; then
+  echo "NDK_ROOT does not exist: $NDK_ROOT"
+  exit 1
+fi
+
+# get libc++_shared.so path
+LIBCPP_SHARED_SO_PATH="${NDK_ROOT}/sysroot/usr/lib/${ANDROID_ARCH}-linux-android/libc++_shared.so"
+adb push $LIBCPP_SHARED_SO_PATH /data/local/tmp/
+
 trap 'cleanup' ERR EXIT
 cleanup() {
   for i in $(cat output-test-executables); do
@@ -12,6 +73,6 @@ cleanup() {
 for i in $(cat output-test-executables); do
   adb push $i /data/local/tmp/$(basename $i)
   adb shell chmod 500 /data/local/tmp/$(basename $i)
-  adb shell TX5_CACHE_DIRECTORY=/data/local/tmp/ RUST_LOG=error RUST_BACKTRACE=1 /data/local/tmp/$(basename $i) --test-threads 1 --nocapture
+  adb shell LD_LIBRARY_PATH=/data/local/tmp TX5_CACHE_DIRECTORY=/data/local/tmp/ RUST_LOG=error RUST_BACKTRACE=1 /data/local/tmp/$(basename $i) --test-threads 1 --nocapture
   adb shell rm -f /data/local/tmp/$(basename $i)
 done

--- a/android-run-tests.bash
+++ b/android-run-tests.bash
@@ -30,21 +30,26 @@ fi
 export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
 
 ndk_root_folder=""
+case "$(uname -m)" in
+  x86_64) ndk_root_folder="linux-x86_64" ;;
+  aarch64) ndk_root_folder="linux-aarch64" ;;
+  *)
+    echo "Unsupported build host arch: $(uname -m)"
+    exit 1
+    ;;
+esac
+
 case "$ANDROID_ARCH" in
   "arm64-v8a")
-    ndk_root_folder="linux-aarch64"
     export ANDROID_ARCH="aarch64"
     ;;
   "armeabi-v7a")
-    ndk_root_folder="linux-arm"
     export ANDROID_ARCH="arm"
     ;;
   "x86")
-    ndk_root_folder="linux-x86"
     export ANDROID_ARCH="i686"
     ;;
   "x86_64")
-    ndk_root_folder="linux-x86_64"
     export ANDROID_ARCH="x86_64"
     ;;
   *)

--- a/crates/tx5-go-pion-sys/build.rs
+++ b/crates/tx5-go-pion-sys/build.rs
@@ -214,13 +214,14 @@ fn go_build_cmd(
     }
 
     // grr, clippy, the debug symbols belong in one arg
+    // NOTE: -checklinkname=0 is required => <https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later>
     #[allow(clippy::suspicious_command_arg_space)]
     {
         cmd.current_dir(out_dir)
             .env("GOCACHE", cache)
             .arg("build")
             .arg("-ldflags") // strip debug symbols
-            .arg("-s -w ".to_string() + &extra_linker_flags) // strip debug symbols
+            .arg("-checklinkname=0 -s -w ".to_string() + &extra_linker_flags) // strip debug symbols
             .arg("-buildvcs=false") // disable version control stamping binary
             .arg("-o")
             .arg(lib_path)


### PR DESCRIPTION
closes #146

Fixed build flags to fix android build.

Push libc++_shared.so to run tests on the emulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CI: Added selectable Android test backends (go-pion, datachannel) via matrix configuration.

- Bug Fixes
  - Adjusted Go linker flags to prevent Android link/build issues.

- Tests
  - Android test runner enhanced: validates env, canonicalizes architectures, selects per-arch NDK toolchains, pushes needed shared libs, sets runtime library paths, and ensures cleanup for reliable multi-arch testing.

- Chores
  - Build/test scripts now export NDK toolchain paths and run targeted Android test invocations.

- Revert
  - None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->