### PR TITLE
test: add test that a second message can be sent successfully to a peer that has disconnected

### DIFF
--- a/crates/tx5/tests/tests/mod.rs
+++ b/crates/tx5/tests/tests/mod.rs
@@ -62,8 +62,31 @@ async fn receive_next_message_from(
                 return message;
             }
             Some(evt) => {
-                tracing::info!("Received unexpected event: {evt:?}");
+                tracing::info!(
+                    "Received event of type we're not waiting for: {evt:?}"
+                );
+                continue; // Ignore other events
+            }
+            None => panic!("Unexpected end of receiver"),
+        }
+    }
+}
 
+async fn wait_for_disconnect_message(r: &mut EndpointRecv, url: PeerUrl) -> () {
+    loop {
+        let evt = r.recv().await;
+        match evt {
+            Some(tx5::EndpointEvent::Disconnected { peer_url }) => {
+                if peer_url != url {
+                    panic!("Received disconnect event associated with unexpected peer: {peer_url}");
+                }
+
+                return;
+            }
+            Some(evt) => {
+                tracing::info!(
+                    "Received event of type we're not waiting for: {evt:?}"
+                );
                 continue; // Ignore other events
             }
             None => panic!("Unexpected end of receiver"),
@@ -74,7 +97,9 @@ async fn receive_next_message_from(
 fn enable_tracing() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(
-            tracing_subscriber::filter::EnvFilter::from_default_env(),
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::Level::DEBUG.into())
+                .from_env_lossy(),
         )
         .with_file(true)
         .with_line_number(true)

--- a/crates/tx5/tests/tests/reconnect.rs
+++ b/crates/tx5/tests/tests/reconnect.rs
@@ -1,6 +1,70 @@
 use crate::tests::{
     enable_tracing, ep, ep_with_config, receive_next_message_from, sbd,
+    wait_for_disconnect_message,
 };
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sending_second_message_after_remote_disconnect_succeeds_after_disconnect_event(
+) {
+    enable_tracing();
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let sbd_server = sbd().await;
+
+    let (peer_url_1, endpoint_1, mut endpoint_recv_1) = ep(&sbd_server).await;
+    let (peer_url_2, endpoint_2, mut endpoint_recv_2) = ep(&sbd_server).await;
+
+    tracing::error!(?peer_url_1);
+    tracing::error!(?peer_url_2);
+
+    endpoint_1
+        .send(peer_url_2.clone(), b"hello".to_vec())
+        .await
+        .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_millis(5_000), async {
+        let msg_1 =
+            receive_next_message_from(&mut endpoint_recv_2, peer_url_1.clone())
+                .await;
+        assert_eq!("hello", String::from_utf8_lossy(&msg_1));
+    })
+    .await
+    .unwrap();
+
+    endpoint_2.close(&peer_url_1);
+
+    // We need to wait until peer 1 learns about the fact that peer 2 has
+    // disconnected before sending the next message. Otherwise we unknowingly
+    // send it over a WebRTC connection at which peer 2 is not listening
+    // anymore.
+    tokio::time::timeout(std::time::Duration::from_millis(5_000), async {
+        wait_for_disconnect_message(&mut endpoint_recv_1, peer_url_2.clone())
+            .await;
+    })
+    .await
+    .unwrap();
+
+    endpoint_1
+        .send(
+            peer_url_2.clone(),
+            b"hello after remote disconnect".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_millis(5_000), async {
+        let msg_2 =
+            receive_next_message_from(&mut endpoint_recv_2, peer_url_1.clone())
+                .await;
+        assert_eq!(
+            "hello after remote disconnect",
+            String::from_utf8_lossy(&msg_2)
+        );
+    })
+    .await
+    .unwrap();
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reconnect_on_webrtc_fail() {


### PR DESCRIPTION
…as long as we wait for our local disconnect event.

If we send a message too quickly after the remote peer disconnected, it falls through the cracks because we still think we're connected while the remote peer has already disconnected and we send it over the stale WebRTC connection without knowing.

This test just documents this behavior and shows that sending a message after the remote disconnects works, provided that we wait until we get our local Disconnect event related to that connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying messages still deliver successfully after a remote peer disconnects.
  * Introduced utilities to wait for and assert disconnect events in test flows.

* **Chores**
  * Improved test logging/tracing defaults for clearer debug output while honoring environment overrides.
  * Made test receivers more robust by ignoring unrelated events and continuing to wait for expected messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->