### PR TITLE
build: bump rust to 1.91, ensure we are using same version in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,10 +36,13 @@ jobs:
 
       - name: Rust Toolchain
         run: |
-          rustup toolchain install stable --profile minimal --no-self-update
-          #rustup target add aarch64-linux-android
+          rustup toolchain install
           rustup target add x86_64-linux-android
-          cargo install --force --locked bindgen-cli
+
+      - name: Rust bindgen tool
+        uses: taiki-e/install-action@v2
+        with:
+          tool: bindgen-cli
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
           macos-latest,
           windows-latest,
         ]
-        toolchain: [
-          stable,
-        ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,10 +29,12 @@ jobs:
 
       - name: Rust Toolchain
         run: |
-          rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
-          rustup default ${{ matrix.toolchain }}
-          rustup component add rustfmt --toolchain ${{ matrix.toolchain }}
-          rustup component add clippy --toolchain ${{ matrix.toolchain }}
+          rustup toolchain install
+
+      - name: Rust bindgen tool
+        uses: taiki-e/install-action@v2
+        with:
+          tool: bindgen-cli
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755078291,
-        "narHash": "sha256-Hu/gTDoi4uy6TAKISPHQusSMy8U6xUbLSDjKBYdhDIY=",
+        "lastModified": 1761597516,
+        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3385ca0cd7e14c1a1eb80401fe011705ff012323",
+        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755225702,
-        "narHash": "sha256-i7Rgs943NqX0RgQW0/l1coi8eWBj3XhxVggMpjjzTsk=",
+        "lastModified": 1761878277,
+        "narHash": "sha256-6fCtyVdTzoQejwoextAu7dCLoy5fyD3WVh+Qm7t2Nhg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4abaeba6b176979be0da0195b9e4ce86bc501ae4",
+        "rev": "6604534e44090c917db714faa58d47861657690c",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
Bump rust to latest stable 1.91. Ensure that CI is using the same rust version specified by rust-toolchain.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rust toolchain updated to 1.91.0.
  * CI workflows streamlined to use a centralized/default toolchain install instead of per-toolchain installs; removed explicit stable matrix entry.
  * Removed inline installation of bindgen; added a dedicated bindgen tooling step.
  * Android target setup retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->