### PR TITLE
build: ensure tests are run with backend-go-pion feature on ci

### DIFF
--- a/crates/tx5/Cargo.toml
+++ b/crates/tx5/Cargo.toml
@@ -49,7 +49,7 @@ futures = { workspace = true }
 sbd-server = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
-tx5 = { path = ".", features = [ "test-utils" ] }
+tx5 = { path = ".", default-features = false, features = [ "test-utils" ] }
 rustls = { workspace = true }
 rand = { workspace = true }
 


### PR DESCRIPTION
The makefile command used to run tests in the `tx5` crate with the feature `backend-go-pion` was not actually using the pion backend. Both `backend-go-pion` and `backend-libdatachannel` features were enabled, so the datachannel backend was used.

Thankfully the tests were passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for development dependencies to optimize feature handling during testing and compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->