### PR TITLE
WIP: Harden Connection Management to Prevent Zombie Connections and Indefinite Blocking

### DIFF
--- a/crates/tx5-connection/src/framed.rs
+++ b/crates/tx5-connection/src/framed.rs
@@ -61,8 +61,8 @@ impl FramedConn {
         let (a, b, c, d) = crate::proto::PROTO_VER_2.encode()?;
         conn.send(vec![a, b, c, d]).await?;
 
-        let (cmd_send, mut cmd_recv) = tokio::sync::mpsc::channel(32);
-        let (msg_send, msg_recv) = tokio::sync::mpsc::channel(32);
+        let (cmd_send, mut cmd_recv) = tokio::sync::mpsc::channel(256);
+        let (msg_send, msg_recv) = tokio::sync::mpsc::channel(256);
 
         // set up the receive to just feed straight into the cmd task
         let cmd_send2 = cmd_send.clone();

--- a/crates/tx5-connection/src/hub.rs
+++ b/crates/tx5-connection/src/hub.rs
@@ -139,7 +139,7 @@ impl Hub {
 
         let mut task_list = Vec::new();
 
-        let (hub_cmd_send, mut cmd_recv) = tokio::sync::mpsc::channel(32);
+        let (hub_cmd_send, mut cmd_recv) = tokio::sync::mpsc::channel(256);
 
         // forward received messages to the cmd task
         let hub_cmd_send2 = hub_cmd_send.clone();

--- a/crates/tx5/src/ep.rs
+++ b/crates/tx5/src/ep.rs
@@ -139,6 +139,12 @@ impl EpInner {
 
     /// Get an existing peer connection or create a new outgoing one.
     pub fn connect_peer(&mut self, peer_url: PeerUrl) -> Arc<Peer> {
+        // Check for stale failed peers before attempting reuse
+        if let Some(existing_peer) = self.peer_map.get(&peer_url) {
+            if existing_peer.is_failed() {
+                self.peer_map.remove(&peer_url);
+            }
+        }
         self.peer_map
             .entry(peer_url.clone())
             .or_insert_with(|| {
@@ -252,9 +258,11 @@ impl Endpoint {
         }
         tokio::time::timeout(self.config.timeout, async {
             let peer = self.inner.lock().unwrap().connect_peer(peer_url.clone());
-            if let Some(conn) = peer.wait_for_ready().await {
+            if let Some(conn) = peer.wait_for_ready(self.config.timeout).await {
                 conn.send(data).await
             } else {
+                // Remove the failed peer from peer_map to prevent reuse of zombie connections
+                self.inner.lock().unwrap().drop_peer_url(&peer_url);
                 // Check to see if a new incoming connection was established
                 // in the mean time. If so, we can send over that.
                 let maybe_peer = self.inner.lock().unwrap().peer_if_ready(

--- a/crates/tx5/src/ep.rs
+++ b/crates/tx5/src/ep.rs
@@ -286,7 +286,7 @@ impl Endpoint {
                 let data = data.to_vec();
                 tokio::task::spawn(async move {
                     let _ = tokio::time::timeout(timeout, async {
-                        if let Some(conn) = peer.wait_for_ready().await {
+                        if let Some(conn) = peer.wait_for_ready(timeout).await {
                             let _ = conn.send(data).await;
                         }
                     })

--- a/crates/tx5/src/ep.rs
+++ b/crates/tx5/src/ep.rs
@@ -199,7 +199,9 @@ impl Endpoint {
             config.incoming_message_bytes_max as usize,
         ));
 
-        let (evt_send, evt_recv) = tokio::sync::mpsc::channel(32);
+        let (evt_send, evt_recv) = tokio::sync::mpsc::channel(
+            config.internal_event_channel_size as usize,
+        );
 
         (
             Self {

--- a/crates/tx5/src/peer.rs
+++ b/crates/tx5/src/peer.rs
@@ -117,6 +117,11 @@ impl Peer {
         self.ready.query_ready(|c| c.clone())
     }
 
+    /// Check if this peer connection has failed
+    pub(crate) fn is_failed(&self) -> bool {
+        self.ready.is_failed()
+    }
+
     /// This future resolves when the connection is ready to use or has failed to connect.
     ///
     /// If the connection is not usable, it will return `None`.

--- a/crates/tx5/src/peer.rs
+++ b/crates/tx5/src/peer.rs
@@ -249,14 +249,22 @@ async fn task(
 ) {
     // establish our cleanup drop guard
     let drop_guard = DropPeer {
-        ep,
+        ep: ep.clone(),
         peer_url: peer_url.clone(),
         evt_send: evt_send.clone(),
         ready: ready.clone(),
     };
 
     let mut wc = match conn {
-        None => return,
+        None => {
+            // Connection failed during negotiation - clean up immediately
+            // to prevent zombie connection reuse
+            if let Some(ep_inner) = ep.upgrade() {
+                ep_inner.lock().unwrap().drop_peer_url(&peer_url);
+            }
+            ready.set_failed();
+            return;
+        }
         Some(wc) => wc,
     };
 

--- a/crates/tx5/src/peer.rs
+++ b/crates/tx5/src/peer.rs
@@ -120,8 +120,11 @@ impl Peer {
     /// This future resolves when the connection is ready to use or has failed to connect.
     ///
     /// If the connection is not usable, it will return `None`.
-    pub async fn wait_for_ready(&self) -> Option<DynBackCon> {
-        self.ready.wait_for_ready().await
+    pub async fn wait_for_ready(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Option<DynBackCon> {
+        self.ready.wait_for_ready(timeout).await
     }
 }
 

--- a/crates/tx5/src/peer/maybe_ready.rs
+++ b/crates/tx5/src/peer/maybe_ready.rs
@@ -73,7 +73,12 @@ impl MaybeReady {
         *lock = MaybeReadyState::Failed;
     }
 
-    pub(super) async fn wait_for_ready(&self) -> Option<DynBackCon> {
+    /// Check if the connection is in a failed state
+    pub(super) fn is_failed(&self) -> bool {
+        let lock = self.0.lock().expect("poisoned");
+        matches!(*lock, MaybeReadyState::Failed)
+    }
+
     pub(super) async fn wait_for_ready(
         &self,
         timeout: std::time::Duration,

--- a/crates/tx5/src/peer/maybe_ready.rs
+++ b/crates/tx5/src/peer/maybe_ready.rs
@@ -74,6 +74,10 @@ impl MaybeReady {
     }
 
     pub(super) async fn wait_for_ready(&self) -> Option<DynBackCon> {
+    pub(super) async fn wait_for_ready(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Option<DynBackCon> {
         let wait = {
             let lock = self.0.lock().expect("poisoned");
             match &*lock {
@@ -83,15 +87,29 @@ impl MaybeReady {
             }
         };
 
-        let _ = wait.acquire().await;
+        // Add timeout wrapper to prevent indefinite blocking
+        let result = tokio::time::timeout(timeout, async {
+            let _ = wait.acquire().await;
+        })
+        .await;
 
-        let lock = self.0.lock().expect("poisoned");
-        match &*lock {
-            MaybeReadyState::Ready(back) => Some(back.clone()),
-            MaybeReadyState::Failed => None,
-            MaybeReadyState::Wait(_) => {
-                // Unexpected state, this struct is supposed to prevent this being possible.
-                tracing::warn!("Waited for ready but still in a wait state");
+        match result {
+            Ok(_) => {
+                // Semaphore acquired, check final state
+                let lock = self.0.lock().expect("poisoned");
+                match &*lock {
+                    MaybeReadyState::Ready(back) => Some(back.clone()),
+                    MaybeReadyState::Failed => None,
+                    MaybeReadyState::Wait(_) => {
+                        // Unexpected state, this struct is supposed to prevent this being possible.
+                        tracing::warn!("Waited for ready but still in a wait state");
+                        None
+                    }
+                }
+            }
+            Err(_) => {
+                // Timeout - connection failed to become ready in time
+                tracing::debug!("wait_for_ready timed out after {:?}", timeout);
                 None
             }
         }
@@ -136,8 +154,13 @@ mod tests {
         tokio::spawn({
             let maybe_ready = maybe_ready.clone();
             async move {
-                tx.send(maybe_ready.wait_for_ready().await.is_some())
-                    .unwrap();
+                tx.send(
+                    maybe_ready
+                        .wait_for_ready(std::time::Duration::from_secs(60))
+                        .await
+                        .is_some(),
+                )
+                .unwrap();
             }
         });
 
@@ -178,8 +201,13 @@ mod tests {
         tokio::spawn({
             let maybe_ready = maybe_ready.clone();
             async move {
-                tx.send(maybe_ready.wait_for_ready().await.is_none())
-                    .unwrap();
+                tx.send(
+                    maybe_ready
+                        .wait_for_ready(std::time::Duration::from_secs(60))
+                        .await
+                        .is_none(),
+                )
+                .unwrap();
             }
         });
 


### PR DESCRIPTION
In the process of diagnosing this flaky test https://github.com/holochain/holochain/issues/4174, I've experimented with these changes in hope to avoid and/or mitigate loss of connection in some cases.

I'm posting this PR for visibility - stopping work on this for now in favor of the iroh transport implementation.

### Summary

This PR tries to fix critical connection management issues that caused threads to block indefinitely on failed connections and allowed zombie connections to remain in the peer map, leading to cascading timeout failures. It also fixes a channel capacity bug that caused "closed" errors under concurrent load.

### Problem

The existing implementation had several critical issues:

1. **Indefinite Blocking**: `wait_for_ready()` would block indefinitely on a semaphore when waiting for peer connections, causing threads to hang forever when connections failed
2. **Zombie Connection Reuse**: Failed connections remained in `peer_map` and were reused by subsequent sends, causing repeated 20-second timeouts
3. **Channel Saturation**: Event channel was hardcoded to 32 slots despite config specifying 1024, causing channel saturation and "closed" errors under concurrent load
4. **No Failed State Detection**: No mechanism to proactively detect and clean up failed peer connections before reuse attempts

### Changes

#### 1. Add Timeout Parameter to `wait_for_ready()` (715648d)
- Wrap semaphore acquire in `tokio::time::timeout` to prevent indefinite blocking
- Add timeout parameter to `MaybeReady::wait_for_ready()` and `Peer::wait_for_ready()`
- Update all call sites to pass `config.timeout`
- Prevents threads from blocking indefinitely on failed connections

#### 2. Add Failed Connection Detection (2a92be6)
- Add `MaybeReady::is_failed()` to check `MaybeReadyState::Failed`
- Add `Peer::is_failed()` wrapper method
- Enables proactive cleanup of zombie connections before reuse attempts

#### 3. Fix Channel Capacity Bug (2b2dc39)
**Critical fix**: Endpoint event channel was hardcoded to 32 despite config specifying 1024
- **ep.rs**: Use `config.internal_event_channel_size` (32→1024, **32x increase**)
- **hub.rs**: Increase hub command channel from 32→256 (**8x increase**)
- **framed.rs**: Increase cmd and msg channels from 32→256 (**8x increase**)
- Prevents channel saturation during concurrent connection establishment and high message throughput

#### 4. Add Aggressive Peer Cleanup (0c9d81f)
Prevents failed connections from remaining in `peer_map` and being reused, which would cause repeated timeouts
- Add stale peer check in `connect_peer()` - remove failed peers before reuse
- Add early cleanup in peer `task()` when connection fails during negotiation
- Add cleanup in `send()` when `wait_for_ready()` times out
- Add debug logging for peer lifecycle events

### Impact

- **Prevents indefinite thread blocking** on failed connections
- **Eliminates zombie connection reuse** that caused cascading timeout failures
- **Fixes channel saturation** under concurrent load (32x increase for main event channel)
- **Enables proactive failed connection detection** and cleanup
- **Improves system reliability** during high-concurrency scenarios and network failures

### Testing

While this changed the signature of flaky test failures, it didn't (yet?) result in 100% stable connections.
